### PR TITLE
ci: add node setup for Astro compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:


### PR DESCRIPTION
## Summary

Add `actions/setup-node@v5` with `node-version: 24` to the CI workflow for Astro/tooling runtime compatibility.

### What changed
- Added Node.js 24 setup step to `.github/workflows/ci.yml`

### What did NOT change
- **Bun remains the package manager, lockfile manager, and script runner**
- Node 24 is added solely for Astro/tooling runtime compatibility
- Only CI workflow was modified — no source code, config, or docs changes

### Checklist
- [x] Node setup placed before Bun setup
- [x] Existing Bun versioning and cache settings preserved
- [x] All downstream checks preserved (dependency review, etc.)
- [x] Local `bun run verify` passed (type-check, lint, format, build, 132 tests)
- [x] No unrelated cleanup or modernization
- [x] Conventional commit used