### PR TITLE
feat(core): harden the current tool suite before tool-page redesign

### DIFF
--- a/src/lib/base64.test.ts
+++ b/src/lib/base64.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   decodeBase64ToBytes,
   decodeBase64ToText,
+  deriveDecodedFileName,
   encodeBytesToBase64,
   encodeTextToBase64,
   processBase64Input,
@@ -40,14 +41,22 @@ describe("base64 utilities", () => {
     });
   });
 
-  it("returns a byte summary for binary decode workflows", () => {
+  it("returns decoded bytes and a preview for binary decode workflows", () => {
     const result = processBase64Input("AP8Q", "decode", "standard", "file");
 
     expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.outputKind).toBe("bytes");
+    if (result.ok && result.outputKind === "bytes") {
+      expect(Array.from(result.bytes)).toEqual([0, 255, 16]);
       expect(result.value).toContain("3 bytes");
       expect(result.value).toContain("00 ff 10");
+      expect(result.downloadName).toBe("decoded.bin");
     }
+  });
+
+  it("derives decoded file names from encoded source names", () => {
+    expect(deriveDecodedFileName()).toBe("decoded.bin");
+    expect(deriveDecodedFileName("archive.tar.b64")).toBe("archive.tar");
+    expect(deriveDecodedFileName("image.png.base64.txt")).toBe("image.png");
+    expect(deriveDecodedFileName("payload.txt")).toBe("payload.txt.decoded.bin");
   });
 });

--- a/src/lib/base64.ts
+++ b/src/lib/base64.ts
@@ -5,11 +5,21 @@ export type Base64Mode = "encode" | "decode";
 export type Base64Workflow = "text" | "file";
 export type Base64DecodeOutputKind = "text" | "bytes";
 
-export interface Base64TransformSuccess {
+export interface Base64TextTransformSuccess {
   ok: true;
   value: string;
-  outputKind: Base64DecodeOutputKind;
+  outputKind: "text";
 }
+
+export interface Base64BinaryTransformSuccess {
+  ok: true;
+  value: string;
+  outputKind: "bytes";
+  bytes: Uint8Array;
+  downloadName: string;
+}
+
+export type Base64TransformSuccess = Base64TextTransformSuccess | Base64BinaryTransformSuccess;
 
 export interface Base64TransformFailure {
   ok: false;
@@ -50,18 +60,41 @@ export function decodeBase64ToText(input: string, variant: Base64Variant): strin
   return new TextDecoder("utf-8", { fatal: true }).decode(decodeBase64ToBytes(input, variant));
 }
 
+export function deriveDecodedFileName(sourceName?: string | null): string {
+  const trimmed = sourceName?.trim();
+  if (!trimmed) {
+    return "decoded.bin";
+  }
+
+  const stripped = trimmed.replace(/(?:\.(?:base64|b64))(?:\.txt)?$/i, "");
+  if (stripped !== trimmed) {
+    return /\.[^.]+$/.test(stripped) ? stripped : `${stripped}.bin`;
+  }
+
+  return `${trimmed}.decoded.bin`;
+}
+
 export function processBase64Input(
   input: string,
   mode: Base64Mode,
   variant: Base64Variant,
-  workflow: Base64Workflow
+  workflow: Base64Workflow,
+  options: { sourceName?: string | null } = {}
 ): Base64TransformResult {
   if (!input.trim()) {
-    return {
-      ok: true,
-      value: "",
-      outputKind: mode === "encode" ? "text" : workflow === "file" ? "bytes" : "text",
-    };
+    return mode === "decode" && workflow === "file"
+      ? {
+          ok: true,
+          value: "",
+          outputKind: "bytes",
+          bytes: new Uint8Array(),
+          downloadName: deriveDecodedFileName(options.sourceName),
+        }
+      : {
+          ok: true,
+          value: "",
+          outputKind: "text",
+        };
   }
 
   try {
@@ -79,6 +112,8 @@ export function processBase64Input(
         ok: true,
         value: formatByteSummary(bytes),
         outputKind: "bytes",
+        bytes,
+        downloadName: deriveDecodedFileName(options.sourceName),
       };
     }
 

--- a/src/lib/cron.test.ts
+++ b/src/lib/cron.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "vitest";
+
+import { parseCronExpression, SUPPORTED_CRON_SYNTAX } from "./cron";
+
+describe("cron parser", () => {
+  it("documents the supported five-field syntax subset", () => {
+    expect(SUPPORTED_CRON_SYNTAX.fieldOrder).toEqual([
+      "minute",
+      "hour",
+      "dayOfMonth",
+      "month",
+      "dayOfWeek",
+    ]);
+    expect(SUPPORTED_CRON_SYNTAX.operators).toEqual(["*", ",", "-", "/"]);
+  });
+
+  it("parses a wildcard-only five-field expression", () => {
+    const result = parseCronExpression("* * * * *");
+
+    expect(result).toEqual({
+      ok: true,
+      value: {
+        minute: { kind: "wildcard", raw: "*" },
+        hour: { kind: "wildcard", raw: "*" },
+        dayOfMonth: { kind: "wildcard", raw: "*" },
+        month: { kind: "wildcard", raw: "*" },
+        dayOfWeek: { kind: "wildcard", raw: "*" },
+      },
+    });
+  });
+
+  it("rejects expressions that do not contain exactly five fields", () => {
+    const result = parseCronExpression("* * * *");
+
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        field: "expression",
+        message: "Cron expressions must contain exactly five fields.",
+      },
+    });
+  });
+
+  it("parses fixed numeric values for each field", () => {
+    const result = parseCronExpression("5 4 3 2 1");
+
+    expect(result).toEqual({
+      ok: true,
+      value: {
+        minute: { kind: "value", raw: "5", value: 5 },
+        hour: { kind: "value", raw: "4", value: 4 },
+        dayOfMonth: { kind: "value", raw: "3", value: 3 },
+        month: { kind: "value", raw: "2", value: 2 },
+        dayOfWeek: { kind: "value", raw: "1", value: 1 },
+      },
+    });
+  });
+
+  it("rejects values outside the allowed field range", () => {
+    const result = parseCronExpression("60 * * * *");
+
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        field: "minute",
+        message: "Minute must be between 0 and 59.",
+      },
+    });
+  });
+
+  it("parses inclusive numeric ranges", () => {
+    const result = parseCronExpression("1-5 * * * *");
+
+    expect(result).toEqual({
+      ok: true,
+      value: {
+        minute: {
+          kind: "range",
+          raw: "1-5",
+          start: 1,
+          end: 5,
+        },
+        hour: { kind: "wildcard", raw: "*" },
+        dayOfMonth: { kind: "wildcard", raw: "*" },
+        month: { kind: "wildcard", raw: "*" },
+        dayOfWeek: { kind: "wildcard", raw: "*" },
+      },
+    });
+  });
+
+  it("parses wildcard steps", () => {
+    const result = parseCronExpression("*/15 * * * *");
+
+    expect(result).toEqual({
+      ok: true,
+      value: {
+        minute: {
+          kind: "step",
+          raw: "*/15",
+          base: { kind: "wildcard", raw: "*" },
+          step: 15,
+        },
+        hour: { kind: "wildcard", raw: "*" },
+        dayOfMonth: { kind: "wildcard", raw: "*" },
+        month: { kind: "wildcard", raw: "*" },
+        dayOfWeek: { kind: "wildcard", raw: "*" },
+      },
+    });
+  });
+
+  it("parses comma-separated lists", () => {
+    const result = parseCronExpression("1,15,30 * * * *");
+
+    expect(result).toEqual({
+      ok: true,
+      value: {
+        minute: {
+          kind: "list",
+          raw: "1,15,30",
+          items: [
+            { kind: "value", raw: "1", value: 1 },
+            { kind: "value", raw: "15", value: 15 },
+            { kind: "value", raw: "30", value: 30 },
+          ],
+        },
+        hour: { kind: "wildcard", raw: "*" },
+        dayOfMonth: { kind: "wildcard", raw: "*" },
+        month: { kind: "wildcard", raw: "*" },
+        dayOfWeek: { kind: "wildcard", raw: "*" },
+      },
+    });
+  });
+
+  it("parses stepped ranges", () => {
+    const result = parseCronExpression("1-10/2 * * * *");
+
+    expect(result).toEqual({
+      ok: true,
+      value: {
+        minute: {
+          kind: "step",
+          raw: "1-10/2",
+          base: {
+            kind: "range",
+            raw: "1-10",
+            start: 1,
+            end: 10,
+          },
+          step: 2,
+        },
+        hour: { kind: "wildcard", raw: "*" },
+        dayOfMonth: { kind: "wildcard", raw: "*" },
+        month: { kind: "wildcard", raw: "*" },
+        dayOfWeek: { kind: "wildcard", raw: "*" },
+      },
+    });
+  });
+
+  it("rejects zero or negative steps", () => {
+    const result = parseCronExpression("*/0 * * * *");
+
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        field: "minute",
+        message: "Minute step must be greater than 0.",
+      },
+    });
+  });
+
+  it("rejects reversed ranges with a specific error", () => {
+    const result = parseCronExpression("10-1 * * * *");
+
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        field: "minute",
+        message: "Minute range start must be less than or equal to the end.",
+      },
+    });
+  });
+
+  it("rejects unsupported aliases and special syntax", () => {
+    const result = parseCronExpression("* * * JAN MON");
+
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        field: "month",
+        message: "Month contains unsupported syntax.",
+      },
+    });
+  });
+});

--- a/src/lib/cron.ts
+++ b/src/lib/cron.ts
@@ -1,0 +1,266 @@
+export type CronFieldName = "minute" | "hour" | "dayOfMonth" | "month" | "dayOfWeek";
+
+export interface CronFieldRangeSpec {
+  min: number;
+  max: number;
+  label: string;
+}
+
+/**
+ * v1 supported cron subset for the parser/validator layer.
+ *
+ * - five fields only: minute hour day-of-month month day-of-week
+ * - numeric values only
+ * - supported operators: wildcard (*), lists (,), ranges (-), and steps (/)
+ * - unsupported for now: aliases (JAN, MON), seconds field, macros (@daily), and special tokens (?, L, W, #)
+ */
+export const CRON_FIELD_SPECS: Record<CronFieldName, CronFieldRangeSpec> = {
+  minute: { min: 0, max: 59, label: "Minute" },
+  hour: { min: 0, max: 23, label: "Hour" },
+  dayOfMonth: { min: 1, max: 31, label: "Day of month" },
+  month: { min: 1, max: 12, label: "Month" },
+  dayOfWeek: { min: 0, max: 6, label: "Day of week" },
+};
+
+export const SUPPORTED_CRON_SYNTAX = {
+  fieldOrder: ["minute", "hour", "dayOfMonth", "month", "dayOfWeek"] as const,
+  operators: ["*", ",", "-", "/"] as const,
+  unsupported: ["aliases", "seconds", "macros", "?", "L", "W", "#"] as const,
+};
+
+export interface CronWildcardField {
+  kind: "wildcard";
+  raw: string;
+}
+
+export interface CronValueField {
+  kind: "value";
+  raw: string;
+  value: number;
+}
+
+export interface CronRangeField {
+  kind: "range";
+  raw: string;
+  start: number;
+  end: number;
+}
+
+export type CronAtomicField = CronWildcardField | CronValueField | CronRangeField;
+
+export interface CronStepField {
+  kind: "step";
+  raw: string;
+  base: CronAtomicField;
+  step: number;
+}
+
+export interface CronListField {
+  kind: "list";
+  raw: string;
+  items: CronAtomicField[];
+}
+
+export type CronField = CronAtomicField | CronStepField | CronListField;
+
+export interface CronExpression {
+  minute: CronField;
+  hour: CronField;
+  dayOfMonth: CronField;
+  month: CronField;
+  dayOfWeek: CronField;
+}
+
+export interface CronParseError {
+  field: CronFieldName | "expression";
+  message: string;
+}
+
+export type CronParseResult =
+  | { ok: true; value: CronExpression }
+  | { ok: false; error: CronParseError };
+
+type CronFieldParseResult = { ok: true; value: CronField } | { ok: false; error: CronParseError };
+type CronAtomicParseResult =
+  | { ok: true; value: CronAtomicField }
+  | { ok: false; error: CronParseError };
+
+function unsupportedSyntaxError(name: CronFieldName): { ok: false; error: CronParseError } {
+  return {
+    ok: false,
+    error: {
+      field: name,
+      message: `${CRON_FIELD_SPECS[name].label} contains unsupported syntax.`,
+    },
+  };
+}
+
+function validateFieldValue(name: CronFieldName, value: number): CronParseError | null {
+  const { min, max, label } = CRON_FIELD_SPECS[name];
+  if (value < min || value > max) {
+    return {
+      field: name,
+      message: `${label} must be between ${min} and ${max}.`,
+    };
+  }
+
+  return null;
+}
+
+function parseAtomicField(name: CronFieldName, raw: string): CronAtomicParseResult {
+  if (raw === "*") {
+    return { ok: true, value: { kind: "wildcard", raw } };
+  }
+
+  if (/^\d+-\d+$/.test(raw)) {
+    const [startText, endText] = raw.split("-");
+    const start = Number.parseInt(startText, 10);
+    const end = Number.parseInt(endText, 10);
+
+    const startError = validateFieldValue(name, start);
+    if (startError) {
+      return { ok: false, error: startError };
+    }
+
+    const endError = validateFieldValue(name, end);
+    if (endError) {
+      return { ok: false, error: endError };
+    }
+
+    if (start > end) {
+      return {
+        ok: false,
+        error: {
+          field: name,
+          message: `${CRON_FIELD_SPECS[name].label} range start must be less than or equal to the end.`,
+        },
+      };
+    }
+
+    return {
+      ok: true,
+      value: {
+        kind: "range",
+        raw,
+        start,
+        end,
+      },
+    };
+  }
+
+  if (!/^\d+$/.test(raw)) {
+    return unsupportedSyntaxError(name);
+  }
+
+  const value = Number.parseInt(raw, 10);
+  const validationError = validateFieldValue(name, value);
+  if (validationError) {
+    return {
+      ok: false,
+      error: validationError,
+    };
+  }
+
+  return {
+    ok: true,
+    value: {
+      kind: "value",
+      raw,
+      value,
+    },
+  };
+}
+
+function parseField(name: CronFieldName, raw: string): CronFieldParseResult {
+  if (raw.includes(",")) {
+    const itemResults = raw.split(",").map((part) => parseAtomicField(name, part));
+    const firstError = itemResults.find((result) => !result.ok);
+    if (firstError && !firstError.ok) {
+      return firstError;
+    }
+
+    return {
+      ok: true,
+      value: {
+        kind: "list",
+        raw,
+        items: itemResults.map((result) => {
+          if (!result.ok) {
+            throw new Error("Unexpected cron list parse failure.");
+          }
+          return result.value;
+        }),
+      },
+    };
+  }
+
+  if (/^.+\/\d+$/.test(raw)) {
+    const [baseRaw, stepRaw] = raw.split("/");
+    const base = parseAtomicField(name, baseRaw);
+    if (!base.ok) return base;
+
+    const step = Number.parseInt(stepRaw, 10);
+    if (step < 1) {
+      return {
+        ok: false,
+        error: {
+          field: name,
+          message: `${CRON_FIELD_SPECS[name].label} step must be greater than 0.`,
+        },
+      };
+    }
+
+    return {
+      ok: true,
+      value: {
+        kind: "step",
+        raw,
+        base: base.value,
+        step,
+      },
+    };
+  }
+
+  return parseAtomicField(name, raw);
+}
+
+export function parseCronExpression(input: string): CronParseResult {
+  const trimmed = input.trim();
+  const parts = trimmed ? trimmed.split(/\s+/) : [];
+
+  if (parts.length !== 5) {
+    return {
+      ok: false,
+      error: {
+        field: "expression",
+        message: "Cron expressions must contain exactly five fields.",
+      },
+    };
+  }
+
+  const minute = parseField("minute", parts[0]);
+  if (!minute.ok) return minute;
+
+  const hour = parseField("hour", parts[1]);
+  if (!hour.ok) return hour;
+
+  const dayOfMonth = parseField("dayOfMonth", parts[2]);
+  if (!dayOfMonth.ok) return dayOfMonth;
+
+  const month = parseField("month", parts[3]);
+  if (!month.ok) return month;
+
+  const dayOfWeek = parseField("dayOfWeek", parts[4]);
+  if (!dayOfWeek.ok) return dayOfWeek;
+
+  return {
+    ok: true,
+    value: {
+      minute: minute.value,
+      hour: hour.value,
+      dayOfMonth: dayOfMonth.value,
+      month: month.value,
+      dayOfWeek: dayOfWeek.value,
+    },
+  };
+}

--- a/src/lib/hash.test.ts
+++ b/src/lib/hash.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { hashText, hashTextWithAlgorithms } from "./hash";
+import { hashBytes, hashBytesWithAlgorithms, hashText, hashTextWithAlgorithms } from "./hash";
 
 describe("hash", () => {
   it("computes a stable SHA-256 digest", async () => {
@@ -9,8 +9,28 @@ describe("hash", () => {
     );
   });
 
-  it("computes all supported digests", async () => {
+  it("hashes raw bytes with the same digest as equivalent text bytes", async () => {
+    const bytes = new TextEncoder().encode("hello");
+
+    await expect(hashBytes(bytes, "SHA-256")).resolves.toBe(
+      "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+    );
+  });
+
+  it("computes all supported digests for text", async () => {
     const results = await hashTextWithAlgorithms("hello");
+
+    expect(results.map((result) => result.algorithm)).toEqual([
+      "SHA-1",
+      "SHA-256",
+      "SHA-384",
+      "SHA-512",
+    ]);
+    expect(results.map((result) => result.hex.length)).toEqual([40, 64, 96, 128]);
+  });
+
+  it("computes all supported digests for bytes", async () => {
+    const results = await hashBytesWithAlgorithms(new Uint8Array([0, 255, 16]));
 
     expect(results.map((result) => result.algorithm)).toEqual([
       "SHA-1",

--- a/src/lib/hash.ts
+++ b/src/lib/hash.ts
@@ -7,21 +7,29 @@ export interface HashResult {
 
 export const HASH_ALGORITHMS: HashAlgorithm[] = ["SHA-1", "SHA-256", "SHA-384", "SHA-512"];
 
-export async function hashText(text: string, algorithm: HashAlgorithm): Promise<string> {
-  const encoder = new TextEncoder();
-  const data = encoder.encode(text);
-  const buffer = await crypto.subtle.digest(algorithm, data);
+export async function hashBytes(bytes: Uint8Array, algorithm: HashAlgorithm): Promise<string> {
+  const buffer = await crypto.subtle.digest(algorithm, bytes as unknown as BufferSource);
 
   return Array.from(new Uint8Array(buffer))
     .map((byte) => byte.toString(16).padStart(2, "0"))
     .join("");
 }
 
-export async function hashTextWithAlgorithms(text: string): Promise<HashResult[]> {
+export async function hashText(text: string, algorithm: HashAlgorithm): Promise<string> {
+  const encoder = new TextEncoder();
+  return hashBytes(encoder.encode(text), algorithm);
+}
+
+export async function hashBytesWithAlgorithms(bytes: Uint8Array): Promise<HashResult[]> {
   return Promise.all(
     HASH_ALGORITHMS.map(async (algorithm) => ({
       algorithm,
-      hex: await hashText(text, algorithm),
+      hex: await hashBytes(bytes, algorithm),
     }))
   );
+}
+
+export async function hashTextWithAlgorithms(text: string): Promise<HashResult[]> {
+  const encoder = new TextEncoder();
+  return hashBytesWithAlgorithms(encoder.encode(text));
 }

--- a/src/lib/jsonFormatter.test.ts
+++ b/src/lib/jsonFormatter.test.ts
@@ -1,10 +1,16 @@
 import { describe, expect, it } from "vitest";
 
-import { formatJson, parseJsonErrorPosition, syntaxHighlightJson } from "./jsonFormatter";
+import {
+  formatJson,
+  parseJsonErrorPosition,
+  parseJsonErrorSourceContext,
+  sortJsonKeys,
+  syntaxHighlightJson,
+} from "./jsonFormatter";
 
 describe("json formatter utilities", () => {
   it("formats JSON with configurable indentation", () => {
-    const result = formatJson('{"b":2,"a":1}', 2, false);
+    const result = formatJson('{"b":2,"a":1}', 2, false, false);
 
     expect(result.error).toBeNull();
     expect(result.raw).toBe(`{
@@ -20,21 +26,67 @@ describe("json formatter utilities", () => {
       "b": 2
     }`,
       2,
-      true
+      true,
+      false
     );
 
     expect(result.raw).toBe('{"a":1,"b":2}');
   });
 
-  it("returns parse errors for invalid JSON", () => {
-    const result = formatJson('{"a":1', 2, false);
+  it("sorts keys recursively when requested", () => {
+    const result = formatJson('{"b":2,"a":{"d":4,"c":3},"z":[{"b":2,"a":1}]}', 2, false, true);
+
+    expect(result.raw).toBe(`{
+  "a": {
+    "c": 3,
+    "d": 4
+  },
+  "b": 2,
+  "z": [
+    {
+      "a": 1,
+      "b": 2
+    }
+  ]
+}`);
+  });
+
+  it("sortJsonKeys preserves array order while sorting object keys", () => {
+    expect(
+      sortJsonKeys([
+        { b: 2, a: 1 },
+        { d: 4, c: 3 },
+      ])
+    ).toEqual([
+      { a: 1, b: 2 },
+      { c: 3, d: 4 },
+    ]);
+  });
+
+  it("returns parse errors with line, column, and nearby context", () => {
+    const result = formatJson('{"a":1,\n"b":\n}', 2, false, false);
 
     expect(result.error).toContain("JSON parse error:");
+    expect(result.errorLine).toBe(3);
+    expect(result.errorColumn).toBe(1);
+    expect(result.errorContext).toContain('2 | "b":');
+    expect(result.errorContext).toContain("3 | }");
+    expect(result.errorContext).toContain("^");
   });
 
   it("extracts line or position details from parser messages", () => {
     expect(parseJsonErrorPosition("Unexpected token at line 4")).toBe(4);
     expect(parseJsonErrorPosition("Unexpected token at position 12")).toBe(12);
+  });
+
+  it("builds source context from parser positions", () => {
+    expect(parseJsonErrorSourceContext('{"a":1,\n"b":\n}', 13)).toEqual({
+      line: 3,
+      column: 1,
+      context: `2 | "b":
+3 | }
+    ^`,
+    });
   });
 
   it("wraps highlighted JSON tokens in span elements", () => {

--- a/src/lib/jsonFormatter.ts
+++ b/src/lib/jsonFormatter.ts
@@ -1,10 +1,21 @@
 export type IndentSize = 2 | 4;
 
+type JsonPrimitive = null | boolean | number | string;
+type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue };
+
 export interface JsonFormatResult {
   html: string;
   raw: string;
   error: string | null;
   errorLine: number | null;
+  errorColumn: number | null;
+  errorContext: string | null;
+}
+
+export interface JsonErrorSourceContext {
+  line: number;
+  column: number;
+  context: string;
 }
 
 export function syntaxHighlightJson(json: string): string {
@@ -30,34 +41,124 @@ export function syntaxHighlightJson(json: string): string {
     );
 }
 
+export function sortJsonKeys<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map((item) => sortJsonKeys(item)) as T;
+  }
+
+  if (typeof value === "object" && value !== null) {
+    return Object.keys(value)
+      .sort((left, right) => left.localeCompare(right))
+      .reduce<Record<string, unknown>>((acc, key) => {
+        acc[key] = sortJsonKeys((value as Record<string, unknown>)[key]);
+        return acc;
+      }, {}) as T;
+  }
+
+  return value;
+}
+
 export function parseJsonErrorPosition(message: string): number | null {
   const match = /line (\d+)/.exec(message) ?? /position (\d+)/.exec(message);
   if (!match) return null;
   return parseInt(match[1], 10);
 }
 
-export function formatJson(input: string, indent: IndentSize, minify: boolean): JsonFormatResult {
-  const trimmed = input.trim();
-  if (!trimmed) return { html: "", raw: "", error: null, errorLine: null };
+export function parseJsonErrorSourceContext(
+  source: string,
+  position: number
+): JsonErrorSourceContext | null {
+  if (!Number.isInteger(position) || position < 0 || position > source.length) {
+    return null;
+  }
 
-  let parsed: unknown;
+  const normalized = source.replace(/\r\n?/g, "\n");
+  const safePosition = Math.min(position, normalized.length);
+  const prefix = normalized.slice(0, safePosition);
+  const line = prefix.split("\n").length;
+  const lastLineBreak = prefix.lastIndexOf("\n");
+  const column = safePosition - lastLineBreak;
+  const lines = normalized.split("\n");
+
+  const targetLine = lines[line - 1] ?? "";
+  const previousLine = line > 1 ? lines[line - 2] : null;
+  const lineNumberWidth = String(line).length;
+  const renderedLines = [
+    previousLine === null
+      ? null
+      : `${String(line - 1).padStart(lineNumberWidth, " ")} | ${previousLine}`,
+    `${String(line).padStart(lineNumberWidth, " ")} | ${targetLine}`,
+    `${" ".repeat(lineNumberWidth)}   ${" ".repeat(Math.max(column - 1, 0))}^`,
+  ].filter((entry): entry is string => entry !== null);
+
+  return {
+    line,
+    column,
+    context: renderedLines.join("\n"),
+  };
+}
+
+function parseJsonErrorContext(input: string, message: string): JsonErrorSourceContext | null {
+  const positionMatch = /position (\d+)/.exec(message);
+  if (positionMatch) {
+    return parseJsonErrorSourceContext(input, parseInt(positionMatch[1], 10));
+  }
+
+  const unexpectedTokenMatch = /Unexpected token '(.+?)'/.exec(message);
+  if (unexpectedTokenMatch) {
+    const token = unexpectedTokenMatch[1];
+    const fallbackPosition = input.lastIndexOf(token);
+    if (fallbackPosition !== -1) {
+      return parseJsonErrorSourceContext(input, fallbackPosition);
+    }
+  }
+
+  return null;
+}
+
+export function formatJson(
+  input: string,
+  indent: IndentSize,
+  minify: boolean,
+  sortKeys: boolean
+): JsonFormatResult {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return {
+      html: "",
+      raw: "",
+      error: null,
+      errorLine: null,
+      errorColumn: null,
+      errorContext: null,
+    };
+  }
+
+  let parsed: JsonValue;
   try {
-    parsed = JSON.parse(trimmed) as unknown;
+    parsed = JSON.parse(trimmed) as JsonValue;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
+    const errorContext = parseJsonErrorContext(trimmed, message);
+
     return {
       html: "",
       raw: "",
       error: `JSON parse error: ${message}`,
-      errorLine: parseJsonErrorPosition(message),
+      errorLine: errorContext?.line ?? null,
+      errorColumn: errorContext?.column ?? null,
+      errorContext: errorContext?.context ?? null,
     };
   }
 
-  const raw = minify ? JSON.stringify(parsed) : JSON.stringify(parsed, null, indent);
+  const output = sortKeys ? sortJsonKeys(parsed) : parsed;
+  const raw = minify ? JSON.stringify(output) : JSON.stringify(output, null, indent);
   return {
     html: syntaxHighlightJson(raw),
     raw,
     error: null,
     errorLine: null,
+    errorColumn: null,
+    errorContext: null,
   };
 }

--- a/src/lib/jwt.test.ts
+++ b/src/lib/jwt.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "vitest";
 
-import { decodeBase64Url, getJwtExpiryStatus, parseJwt, prettyJson } from "./jwt";
+import {
+  decodeBase64Url,
+  formatJwtTimestamp,
+  getJwtClaimsSummary,
+  getJwtExpiryStatus,
+  parseJwt,
+  prettyJson,
+} from "./jwt";
 
 describe("jwt utilities", () => {
   it("decodes base64url JSON payloads", () => {
@@ -26,6 +33,40 @@ describe("jwt utilities", () => {
     expect(getJwtExpiryStatus({ exp: 100 }, 200)?.expired).toBe(true);
     expect(getJwtExpiryStatus({ exp: 300 }, 200)?.expired).toBe(false);
     expect(getJwtExpiryStatus({ sub: "123" }, 200)).toBeNull();
+  });
+
+  it("formats registered timestamp claims predictably", () => {
+    expect(formatJwtTimestamp(1_900_000_000)).toContain("2030");
+  });
+
+  it("extracts standard claims into a compact summary", () => {
+    const summary = getJwtClaimsSummary({
+      header: { alg: "HS256", typ: "JWT" },
+      payload: {
+        iss: "issuer",
+        sub: "123",
+        aud: ["web", "mobile"],
+        exp: 1_900_000_000,
+        iat: 1_800_000_000,
+        jti: "token-id",
+      },
+      signature: "signature",
+    });
+
+    expect(summary.map((item) => item.key)).toEqual([
+      "alg",
+      "typ",
+      "iss",
+      "sub",
+      "aud",
+      "exp",
+      "iat",
+      "jti",
+    ]);
+    expect(summary.find((item) => item.key === "aud")?.rawValue).toBe('["web","mobile"]');
+    expect(summary.find((item) => item.key === "exp")?.displayValue).toContain("2030");
+    expect(summary.find((item) => item.key === "alg")?.section).toBe("header");
+    expect(summary.find((item) => item.key === "sub")?.section).toBe("payload");
   });
 
   it("pretty prints arbitrary values", () => {

--- a/src/lib/jwt.ts
+++ b/src/lib/jwt.ts
@@ -9,6 +9,41 @@ export interface JwtExpiryStatus {
   label: string;
 }
 
+export type RegisteredJwtClaimKey =
+  | "alg"
+  | "typ"
+  | "iss"
+  | "sub"
+  | "aud"
+  | "exp"
+  | "nbf"
+  | "iat"
+  | "jti";
+
+export interface JwtClaimSummaryItem {
+  key: RegisteredJwtClaimKey;
+  label: string;
+  rawValue: string;
+  displayValue: string;
+  section: "header" | "payload";
+}
+
+const REGISTERED_CLAIMS: Array<{
+  key: RegisteredJwtClaimKey;
+  label: string;
+  section: "header" | "payload";
+}> = [
+  { key: "alg", label: "Algorithm", section: "header" },
+  { key: "typ", label: "Type", section: "header" },
+  { key: "iss", label: "Issuer", section: "payload" },
+  { key: "sub", label: "Subject", section: "payload" },
+  { key: "aud", label: "Audience", section: "payload" },
+  { key: "exp", label: "Expires", section: "payload" },
+  { key: "nbf", label: "Not before", section: "payload" },
+  { key: "iat", label: "Issued at", section: "payload" },
+  { key: "jti", label: "JWT ID", section: "payload" },
+];
+
 export function decodeBase64Url(str: string): unknown {
   const base64 = str.replace(/-/g, "+").replace(/_/g, "/");
   const padded = base64 + "=".repeat((4 - (base64.length % 4)) % 4);
@@ -53,8 +88,60 @@ export function prettyJson(value: unknown): string {
   return JSON.stringify(value, null, 2);
 }
 
-export function formatJwtExpiry(exp: number): string {
-  return new Date(exp * 1000).toLocaleString();
+export function formatJwtTimestamp(value: number): string {
+  return new Date(value * 1000).toLocaleString();
+}
+
+function stringifyJwtClaimValue(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  return JSON.stringify(value);
+}
+
+function getClaimContainer(
+  parsed: ParsedJwt,
+  section: "header" | "payload"
+): Record<string, unknown> | null {
+  const value = parsed[section];
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return null;
+  }
+
+  return value as Record<string, unknown>;
+}
+
+function humanizeRegisteredClaim(key: RegisteredJwtClaimKey, value: unknown): string {
+  if (["exp", "nbf", "iat"].includes(key) && typeof value === "number") {
+    return formatJwtTimestamp(value);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => stringifyJwtClaimValue(entry)).join(", ");
+  }
+
+  return stringifyJwtClaimValue(value);
+}
+
+export function getJwtClaimsSummary(parsed: ParsedJwt): JwtClaimSummaryItem[] {
+  return REGISTERED_CLAIMS.flatMap((claim) => {
+    const container = getClaimContainer(parsed, claim.section);
+    if (!container || !(claim.key in container)) {
+      return [];
+    }
+
+    const value = container[claim.key];
+    return [
+      {
+        key: claim.key,
+        label: claim.label,
+        rawValue: stringifyJwtClaimValue(value),
+        displayValue: humanizeRegisteredClaim(claim.key, value),
+        section: claim.section,
+      },
+    ];
+  });
 }
 
 export function getJwtExpiryStatus(
@@ -70,7 +157,7 @@ export function getJwtExpiryStatus(
   return {
     expired,
     label: expired
-      ? `Token expired — ${formatJwtExpiry(exp)}`
-      : `Valid until ${formatJwtExpiry(exp)}`,
+      ? `Token expired — ${formatJwtTimestamp(exp)}`
+      : `Valid until ${formatJwtTimestamp(exp)}`,
   };
 }

--- a/src/lib/timestamp.test.ts
+++ b/src/lib/timestamp.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import { formatInZone, localInputToMs, msToLocalInput, parseEpoch } from "./timestamp";
+import {
+  formatInZone,
+  getDerivedTimestampFormats,
+  localInputToMs,
+  msToLocalInput,
+  parseEpoch,
+} from "./timestamp";
 
 describe("timestamp", () => {
   it("detects seconds and milliseconds epoch inputs", () => {
@@ -19,5 +25,26 @@ describe("timestamp", () => {
   it("formats valid and invalid timezones predictably", () => {
     expect(formatInZone(new Date(Date.UTC(2024, 0, 2, 3, 4, 5)), "UTC")).toContain("03:04:05");
     expect(formatInZone(new Date(), "Not/AZone")).toBe("Invalid timezone");
+  });
+
+  it("builds a derived output matrix from a canonical date", () => {
+    const derived = getDerivedTimestampFormats(new Date(Date.UTC(2024, 0, 2, 3, 4, 5)));
+
+    expect(derived.map((item) => item.label)).toEqual([
+      "ISO 8601",
+      "RFC 3339",
+      "RFC 7231",
+      "UTC string",
+      "ISO 9075",
+      "Mongo ObjectID seed",
+    ]);
+    expect(derived.find((item) => item.label === "RFC 3339")?.value).toBe(
+      "2024-01-02T03:04:05.000Z"
+    );
+    expect(derived.find((item) => item.label === "RFC 7231")?.value).toBe(
+      "Tue, 02 Jan 2024 03:04:05 GMT"
+    );
+    expect(derived.find((item) => item.label === "ISO 9075")?.value).toBe("2024-01-02 03:04:05");
+    expect(derived.find((item) => item.label === "Mongo ObjectID seed")?.value).toBe("65937d25");
   });
 });

--- a/src/lib/timestamp.ts
+++ b/src/lib/timestamp.ts
@@ -3,6 +3,11 @@ export interface TimeZoneOption {
   tz: string;
 }
 
+export interface DerivedTimestampFormat {
+  label: string;
+  value: string;
+}
+
 export const DEFAULT_ZONES: TimeZoneOption[] = [
   { label: "UTC", tz: "UTC" },
   { label: "US/Eastern", tz: "America/New_York" },
@@ -65,6 +70,41 @@ export function formatInZone(date: Date, tz: string): string {
   } catch {
     return "Invalid timezone";
   }
+}
+
+export function formatUtcString(date: Date): string {
+  return date.toUTCString();
+}
+
+export function formatRfc3339(date: Date): string {
+  return date.toISOString();
+}
+
+export function formatRfc7231(date: Date): string {
+  return date.toUTCString();
+}
+
+export function formatIso9075(date: Date): string {
+  const pad = (value: number) => String(value).padStart(2, "0");
+
+  return `${date.getUTCFullYear()}-${pad(date.getUTCMonth() + 1)}-${pad(date.getUTCDate())} ${pad(date.getUTCHours())}:${pad(date.getUTCMinutes())}:${pad(date.getUTCSeconds())}`;
+}
+
+export function formatMongoObjectIdSeed(date: Date): string {
+  return Math.floor(date.getTime() / 1000)
+    .toString(16)
+    .padStart(8, "0");
+}
+
+export function getDerivedTimestampFormats(date: Date): DerivedTimestampFormat[] {
+  return [
+    { label: "ISO 8601", value: date.toISOString() },
+    { label: "RFC 3339", value: formatRfc3339(date) },
+    { label: "RFC 7231", value: formatRfc7231(date) },
+    { label: "UTC string", value: formatUtcString(date) },
+    { label: "ISO 9075", value: formatIso9075(date) },
+    { label: "Mongo ObjectID seed", value: formatMongoObjectIdSeed(date) },
+  ];
 }
 
 export function localInputToMs(value: string): number | null {

--- a/src/tools/base64/Base64Tool.tsx
+++ b/src/tools/base64/Base64Tool.tsx
@@ -44,7 +44,9 @@ export default function Base64Tool() {
       };
     }
 
-    return processBase64Input(textInput(), mode(), variant(), workflow());
+    return processBase64Input(textInput(), mode(), variant(), workflow(), {
+      sourceName: loadedFile()?.name,
+    });
   });
   const outputValue = createMemo(() => {
     const current = result();
@@ -53,6 +55,10 @@ export default function Base64Tool() {
   const transformError = createMemo(() => {
     const current = result();
     return current.ok ? null : current.error;
+  });
+  const binaryOutput = createMemo(() => {
+    const current = result();
+    return current.ok && current.outputKind === "bytes" ? current : null;
   });
   const fileSummary = createMemo(() => {
     const file = loadedFile();
@@ -157,6 +163,23 @@ export default function Base64Tool() {
     e.preventDefault();
     const file = e.dataTransfer?.files?.[0];
     if (file) handleFile(file);
+  }
+
+  function downloadDecodedBytes() {
+    const current = result();
+    if (!current.ok || current.outputKind !== "bytes" || current.bytes.length === 0) {
+      return;
+    }
+
+    const blob = new Blob([current.bytes as unknown as BlobPart], {
+      type: "application/octet-stream",
+    });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = current.downloadName;
+    link.click();
+    URL.revokeObjectURL(url);
   }
 
   const fileReadErrorMessage = () => {
@@ -404,10 +427,12 @@ export default function Base64Tool() {
                     ? "Base64url"
                     : "Base64"
                   : workflow() === "file"
-                    ? "Decoded bytes"
+                    ? "Decoded bytes · binary output"
                     : "Decoded text"}
               </span>
-              <CopyButton text={value()} />
+              <Show when={binaryOutput()} fallback={<CopyButton text={value()} />}>
+                <ToolActionButton onClick={downloadDecodedBytes}>Download file</ToolActionButton>
+              </Show>
             </div>
 
             {/* Output body */}

--- a/src/tools/hash-generator/HashGenerator.tsx
+++ b/src/tools/hash-generator/HashGenerator.tsx
@@ -1,22 +1,45 @@
-import { createSignal, For, onCleanup, Show } from "solid-js";
+import { createMemo, createSignal, For, onCleanup, Show } from "solid-js";
 
 import CopyButton from "@/components/CopyButton";
 import ToolActionButton from "@/components/ToolActionButton";
 import ToolStatusMessage from "@/components/ToolStatusMessage";
-import { type HashResult, hashTextWithAlgorithms } from "@/lib/hash";
+import {
+  DEFAULT_IMPORT_MAX_BYTES,
+  type FileImportError,
+  formatBytes,
+  type ImportedFileMeta,
+  readImportedFile,
+} from "@/lib/fileImport";
+import { hashBytesWithAlgorithms, type HashResult, hashTextWithAlgorithms } from "@/lib/hash";
 
-// ---------------------------------------------------------------------------
-// Main component
-// ---------------------------------------------------------------------------
+type HashWorkflow = "text" | "file";
 
 export default function HashGenerator() {
+  const [workflow, setWorkflow] = createSignal<HashWorkflow>("text");
   const [input, setInput] = createSignal("");
   const [results, setResults] = createSignal<HashResult[]>([]);
   const [computing, setComputing] = createSignal(false);
+  const [fileError, setFileError] = createSignal<FileImportError | null>(null);
+  const [loadedFile, setLoadedFile] = createSignal<ImportedFileMeta | null>(null);
+  const [loadedFileBytes, setLoadedFileBytes] = createSignal<Uint8Array | null>(null);
+  const [fileNotice, setFileNotice] = createSignal<string | null>(null);
 
   let debounceTimer: ReturnType<typeof setTimeout> | undefined;
 
-  async function compute(text: string) {
+  const fileSummary = createMemo(() => {
+    const file = loadedFile();
+    if (!file) {
+      return "";
+    }
+
+    return `${file.name}\n${formatBytes(file.size)}${file.type ? `\n${file.type}` : ""}`;
+  });
+  const readFileError = createMemo(() => {
+    const error = fileError();
+    return error?.code === "read-failed" ? error : null;
+  });
+
+  async function computeText(text: string) {
     if (!text.trim()) {
       setResults([]);
       setComputing(false);
@@ -26,8 +49,23 @@ export default function HashGenerator() {
     setComputing(true);
 
     try {
-      const computed = await hashTextWithAlgorithms(text);
-      setResults(computed);
+      setResults(await hashTextWithAlgorithms(text));
+    } finally {
+      setComputing(false);
+    }
+  }
+
+  async function computeBytes(bytes: Uint8Array) {
+    if (bytes.length === 0) {
+      setResults([]);
+      setComputing(false);
+      return;
+    }
+
+    setComputing(true);
+
+    try {
+      setResults(await hashBytesWithAlgorithms(bytes));
     } finally {
       setComputing(false);
     }
@@ -35,8 +73,22 @@ export default function HashGenerator() {
 
   function handleInput(value: string) {
     setInput(value);
+    setFileError(null);
+    setFileNotice(null);
     clearTimeout(debounceTimer);
-    debounceTimer = setTimeout(() => void compute(value), 300);
+    debounceTimer = setTimeout(() => void computeText(value), 300);
+  }
+
+  function handleWorkflowChange(nextWorkflow: HashWorkflow) {
+    clearTimeout(debounceTimer);
+    setWorkflow(nextWorkflow);
+    setInput("");
+    setResults([]);
+    setComputing(false);
+    setFileError(null);
+    setLoadedFile(null);
+    setLoadedFileBytes(null);
+    setFileNotice(null);
   }
 
   function handleClear() {
@@ -44,6 +96,48 @@ export default function HashGenerator() {
     setInput("");
     setResults([]);
     setComputing(false);
+    setFileError(null);
+    setLoadedFile(null);
+    setLoadedFileBytes(null);
+    setFileNotice(null);
+    setWorkflow("text");
+  }
+
+  async function handleFile(file: File) {
+    clearTimeout(debounceTimer);
+    setFileError(null);
+    setFileNotice(null);
+
+    const result = await readImportedFile(file, {
+      as: "bytes",
+      policy: { maxBytes: DEFAULT_IMPORT_MAX_BYTES },
+    });
+
+    if (!result.ok) {
+      setFileError(result.error);
+      setResults([]);
+      return;
+    }
+
+    if (result.decision.status === "warn") {
+      setFileNotice(
+        `${result.file.name} is ${formatBytes(result.file.size)}. Large files may take longer to hash.`
+      );
+    }
+
+    setWorkflow("file");
+    setLoadedFile(result.file);
+    setLoadedFileBytes(result.value);
+    setInput("");
+    await computeBytes(result.value);
+  }
+
+  function onDrop(event: DragEvent) {
+    event.preventDefault();
+    const file = event.dataTransfer?.files?.[0];
+    if (file) {
+      void handleFile(file);
+    }
   }
 
   onCleanup(() => {
@@ -70,16 +164,37 @@ export default function HashGenerator() {
           gap: "0.75rem",
         }}
       >
+        <div style={{ display: "flex", gap: "0.25rem", "align-items": "center" }}>
+          <ToolActionButton
+            active={workflow() === "text"}
+            variant={workflow() === "text" ? "primary" : "ghost"}
+            onClick={() => handleWorkflowChange("text")}
+          >
+            Text
+          </ToolActionButton>
+          <ToolActionButton
+            active={workflow() === "file"}
+            variant={workflow() === "file" ? "primary" : "ghost"}
+            onClick={() => handleWorkflowChange("file")}
+          >
+            File
+          </ToolActionButton>
+        </div>
+
         <ToolActionButton
-          onClick={() => void compute(input())}
+          onClick={() =>
+            workflow() === "file"
+              ? loadedFileBytes() && void computeBytes(loadedFileBytes() ?? new Uint8Array())
+              : void computeText(input())
+          }
           variant="primary"
-          disabled={!input().trim()}
+          disabled={workflow() === "file" ? !loadedFileBytes() : !input().trim()}
         >
           Hash input
         </ToolActionButton>
         <ToolActionButton
           onClick={handleClear}
-          disabled={!input().trim() && results().length === 0}
+          disabled={!input().trim() && !loadedFileBytes() && results().length === 0}
         >
           Clear
         </ToolActionButton>
@@ -98,41 +213,88 @@ export default function HashGenerator() {
             color: "var(--text-secondary)",
           }}
         >
-          Input text
+          {workflow() === "text" ? "Input text" : "Input file"}
         </label>
-        <textarea
-          value={input()}
-          onInput={(e) => handleInput(e.currentTarget.value)}
-          placeholder="Type or paste text to hash…"
-          rows={5}
-          spellcheck={false}
-          style={{
-            width: "100%",
-            padding: "0.875rem 1rem",
-            "border-radius": "0.5rem",
-            border: "1px solid var(--border)",
-            background: "var(--bg-secondary)",
-            color: "var(--text-primary)",
-            "font-family": "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
-            "font-size": "0.875rem",
-            "line-height": "1.6",
-            resize: "vertical",
-            outline: "none",
-            "box-sizing": "border-box",
-          }}
-        />
+        <div
+          onDragOver={(event) => event.preventDefault()}
+          onDrop={onDrop}
+          style={{ position: "relative" }}
+        >
+          <textarea
+            value={workflow() === "file" ? fileSummary() : input()}
+            onInput={(event) => handleInput(event.currentTarget.value)}
+            placeholder={
+              workflow() === "text"
+                ? "Type or paste text to hash…"
+                : "Drop a file here or use the file picker to hash it locally…"
+            }
+            rows={5}
+            spellcheck={false}
+            readOnly={workflow() === "file"}
+            style={{
+              width: "100%",
+              padding: "0.875rem 1rem",
+              "border-radius": "0.5rem",
+              border: "1px solid var(--border)",
+              background: "var(--bg-secondary)",
+              color: "var(--text-primary)",
+              "font-family": "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+              "font-size": "0.875rem",
+              "line-height": "1.6",
+              resize: "vertical",
+              outline: "none",
+              "box-sizing": "border-box",
+            }}
+          />
+        </div>
+
+        <div style={{ display: "flex", "align-items": "center", gap: "0.5rem" }}>
+          <label
+            style={{
+              "font-size": "0.8125rem",
+              color: "var(--accent-primary)",
+              cursor: "pointer",
+            }}
+          >
+            Open file
+            <input
+              type="file"
+              style={{ display: "none" }}
+              onChange={(event) => {
+                const file = event.currentTarget.files?.[0];
+                if (file) {
+                  void handleFile(file);
+                }
+                event.currentTarget.value = "";
+              }}
+            />
+          </label>
+          <span style={{ "font-size": "0.8125rem", color: "var(--text-muted)" }}>
+            Shared local file import flow with explicit read and size failures
+          </span>
+        </div>
       </div>
 
-      {/* ------------------------------------------------------------------ */}
-      {/* Computing indicator                                                 */}
-      {/* ------------------------------------------------------------------ */}
+      <Show when={fileNotice()}>
+        <ToolStatusMessage tone="warning">{fileNotice()}</ToolStatusMessage>
+      </Show>
+      <Show when={fileError()?.code === "file-too-large"}>
+        <ToolStatusMessage tone="error">
+          File is too large. Maximum supported size is {formatBytes(DEFAULT_IMPORT_MAX_BYTES)}.
+        </ToolStatusMessage>
+      </Show>
+      <Show when={readFileError()}>
+        {(error) => (
+          <ToolStatusMessage tone="error">
+            {error().file.name} could not be read. {error().message}.
+          </ToolStatusMessage>
+        )}
+      </Show>
+
       <Show when={computing()}>
         <ToolStatusMessage tone="muted">Computing…</ToolStatusMessage>
       </Show>
 
-      {/* ------------------------------------------------------------------ */}
-      {/* Results                                                             */}
-      {/* ------------------------------------------------------------------ */}
       <Show when={results().length > 0}>
         <div
           style={{
@@ -151,7 +313,6 @@ export default function HashGenerator() {
                   overflow: "hidden",
                 }}
               >
-                {/* Row header */}
                 <div
                   style={{
                     display: "flex",
@@ -175,7 +336,6 @@ export default function HashGenerator() {
                   <CopyButton text={result.hex} />
                 </div>
 
-                {/* Hash value */}
                 <pre
                   style={{
                     margin: "0",
@@ -197,10 +357,9 @@ export default function HashGenerator() {
         </div>
       </Show>
 
-      {/* Empty hint */}
-      <Show when={!input().trim() && results().length === 0}>
+      <Show when={!input().trim() && !loadedFileBytes() && results().length === 0}>
         <ToolStatusMessage tone="muted">
-          SHA-1 · SHA-256 · SHA-384 · SHA-512 computed via the browser's Web Crypto API
+          SHA-1 · SHA-256 · SHA-384 · SHA-512 computed locally for text and file workflows
         </ToolStatusMessage>
       </Show>
     </div>

--- a/src/tools/json-formatter/JsonFormatter.tsx
+++ b/src/tools/json-formatter/JsonFormatter.tsx
@@ -7,7 +7,10 @@ export default function JsonFormatter() {
   const [input, setInput] = createSignal("");
   const [indent, setIndent] = createSignal<IndentSize>(2);
   const [minify, setMinify] = createSignal(false);
-  const result = createMemo((): JsonFormatResult => formatJson(input(), indent(), minify()));
+  const [sortKeys, setSortKeys] = createSignal(false);
+  const result = createMemo(
+    (): JsonFormatResult => formatJson(input(), indent(), minify(), sortKeys())
+  );
 
   const tabStyle = (active: boolean) => ({
     padding: "0.25rem 0.625rem",
@@ -90,6 +93,24 @@ export default function JsonFormatter() {
           Minify
         </button>
 
+        <button
+          style={{
+            padding: "0.25rem 0.75rem",
+            "border-radius": "0.375rem",
+            border: `1px solid ${sortKeys() ? "var(--accent-primary)" : "var(--border)"}`,
+            background: sortKeys()
+              ? "color-mix(in srgb, var(--accent-primary) 15%, transparent)"
+              : "var(--bg-secondary)",
+            color: sortKeys() ? "var(--accent-primary)" : "var(--text-secondary)",
+            "font-size": "0.75rem",
+            "font-weight": "600",
+            cursor: "pointer",
+          }}
+          onClick={() => setSortKeys((value) => !value)}
+        >
+          Sort keys
+        </button>
+
         <Show when={input().trim()}>
           <button
             style={{
@@ -151,16 +172,50 @@ export default function JsonFormatter() {
           <div
             role="alert"
             style={{
+              display: "flex",
+              "flex-direction": "column",
+              gap: "0.75rem",
               padding: "0.75rem 1rem",
               "border-radius": "0.5rem",
               border: "1px solid var(--accent-error)",
               background: "color-mix(in srgb, var(--accent-error) 12%, transparent)",
               color: "var(--accent-error)",
               "font-size": "0.875rem",
-              "font-family": "var(--font-mono)",
             }}
           >
-            {msg()}
+            <div style={{ "font-family": "var(--font-mono)" }}>{msg()}</div>
+            <Show when={result().errorLine && result().errorColumn}>
+              <div
+                style={{
+                  color: "var(--text-secondary)",
+                  "font-size": "0.8125rem",
+                  "font-family": "var(--font-mono)",
+                }}
+              >
+                Line {result().errorLine}, column {result().errorColumn}
+              </div>
+            </Show>
+            <Show when={result().errorContext}>
+              {(context) => (
+                <pre
+                  style={{
+                    margin: "0",
+                    padding: "0.75rem",
+                    background: "color-mix(in srgb, var(--bg-secondary) 88%, transparent)",
+                    color: "var(--text-primary)",
+                    border: "1px solid var(--border)",
+                    "border-radius": "0.375rem",
+                    "font-size": "0.8125rem",
+                    "line-height": "1.5",
+                    "font-family": "var(--font-mono)",
+                    "white-space": "pre-wrap",
+                    "word-break": "break-word",
+                  }}
+                >
+                  {context()}
+                </pre>
+              )}
+            </Show>
           </div>
         )}
       </Show>
@@ -193,7 +248,9 @@ export default function JsonFormatter() {
                   color: "var(--text-secondary)",
                 }}
               >
-                {minify() ? "Minified" : `Formatted · ${indent()} spaces`}
+                {minify()
+                  ? `Minified${sortKeys() ? " · sorted" : ""}`
+                  : `Formatted · ${indent()} spaces${sortKeys() ? " · sorted" : ""}`}
               </span>
               <CopyButton text={result().raw} />
             </div>

--- a/src/tools/jwt-decoder/JwtDecoder.tsx
+++ b/src/tools/jwt-decoder/JwtDecoder.tsx
@@ -1,7 +1,7 @@
 import { createMemo, createSignal, Show } from "solid-js";
 
 import CopyButton from "@/components/CopyButton";
-import { getJwtExpiryStatus, parseJwt, prettyJson } from "@/lib/jwt";
+import { getJwtClaimsSummary, getJwtExpiryStatus, parseJwt, prettyJson } from "@/lib/jwt";
 
 // ---------------------------------------------------------------------------
 // Sub-components
@@ -84,6 +84,11 @@ export default function JwtDecoder() {
     if (!raw) return null;
     if (parsed() === null) return "Invalid JWT — expected three base64url parts separated by dots.";
     return null;
+  });
+
+  const claimsSummary = createMemo(() => {
+    const result = parsed();
+    return result ? getJwtClaimsSummary(result) : [];
   });
 
   /** Expiry status derived from the payload's `exp` claim. */
@@ -210,6 +215,95 @@ export default function JwtDecoder() {
                   {status().label}
                 </div>
               )}
+            </Show>
+
+            <Show when={claimsSummary().length > 0}>
+              <div
+                style={{
+                  background: "var(--bg-secondary)",
+                  border: "1px solid var(--border)",
+                  "border-radius": "0.5rem",
+                  overflow: "hidden",
+                }}
+              >
+                <div
+                  style={{
+                    display: "flex",
+                    "align-items": "center",
+                    "justify-content": "space-between",
+                    padding: "0.625rem 1rem",
+                    "border-bottom": "1px solid var(--border)",
+                  }}
+                >
+                  <span
+                    style={{
+                      "font-size": "0.75rem",
+                      "font-weight": "600",
+                      "letter-spacing": "0.05em",
+                      "text-transform": "uppercase",
+                      color: "var(--text-secondary)",
+                    }}
+                  >
+                    Claims summary
+                  </span>
+                </div>
+                <div
+                  style={{
+                    display: "grid",
+                    "grid-template-columns": "repeat(auto-fit, minmax(220px, 1fr))",
+                    gap: "0.75rem",
+                    padding: "1rem",
+                  }}
+                >
+                  {claimsSummary().map((item) => (
+                    <div
+                      style={{
+                        display: "flex",
+                        "flex-direction": "column",
+                        gap: "0.25rem",
+                        padding: "0.75rem",
+                        background: "var(--bg-primary)",
+                        border: "1px solid var(--border)",
+                        "border-radius": "0.375rem",
+                      }}
+                    >
+                      <span
+                        style={{
+                          "font-size": "0.6875rem",
+                          "font-weight": "700",
+                          "letter-spacing": "0.06em",
+                          "text-transform": "uppercase",
+                          color: "var(--text-muted)",
+                        }}
+                      >
+                        {item.section} · {item.label}
+                      </span>
+                      <code
+                        style={{
+                          color: "var(--text-primary)",
+                          "font-size": "0.8125rem",
+                          "font-family": "var(--font-mono)",
+                          "word-break": "break-word",
+                        }}
+                      >
+                        {item.displayValue}
+                      </code>
+                      <Show when={item.displayValue !== item.rawValue}>
+                        <span
+                          style={{
+                            color: "var(--text-secondary)",
+                            "font-size": "0.75rem",
+                            "font-family": "var(--font-mono)",
+                            "word-break": "break-word",
+                          }}
+                        >
+                          raw: {item.rawValue}
+                        </span>
+                      </Show>
+                    </div>
+                  ))}
+                </div>
+              </div>
             </Show>
 
             {/* Header panel */}

--- a/src/tools/timestamp/TimestampTool.tsx
+++ b/src/tools/timestamp/TimestampTool.tsx
@@ -6,6 +6,7 @@ import ToolStatusMessage from "@/components/ToolStatusMessage";
 import {
   DEFAULT_ZONES,
   formatInZone,
+  getDerivedTimestampFormats,
   localInputToMs,
   msToLocalInput,
   parseEpoch,
@@ -277,6 +278,69 @@ export default function TimestampTool() {
         )}
       </Show>
 
+      <Show when={date()}>
+        {(d) => (
+          <div
+            style={{
+              background: "var(--bg-secondary)",
+              border: "1px solid var(--border)",
+              "border-radius": "0.5rem",
+              overflow: "hidden",
+            }}
+          >
+            <div
+              style={{
+                padding: "0.625rem 1rem",
+                "border-bottom": "1px solid var(--border)",
+              }}
+            >
+              <span style={labelStyle}>Derived formats</span>
+            </div>
+
+            <div
+              style={{
+                padding: "0.75rem 1rem",
+                display: "grid",
+                "grid-template-columns": "repeat(auto-fit, minmax(220px, 1fr))",
+                gap: "0.75rem",
+              }}
+            >
+              <For each={getDerivedTimestampFormats(d())}>
+                {(item) => (
+                  <div
+                    style={{
+                      display: "flex",
+                      "flex-direction": "column",
+                      gap: "0.375rem",
+                      padding: "0.75rem",
+                      background: "var(--bg-primary)",
+                      border: "1px solid var(--border)",
+                      "border-radius": "0.375rem",
+                    }}
+                  >
+                    <span style={labelStyle}>{item.label}</span>
+                    <code
+                      style={{
+                        "font-size": "0.8125rem",
+                        color: "var(--text-primary)",
+                        "font-family":
+                          "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+                        "word-break": "break-all",
+                      }}
+                    >
+                      {item.value}
+                    </code>
+                    <div style={{ display: "flex", "justify-content": "flex-end" }}>
+                      <CopyButton text={item.value} />
+                    </div>
+                  </div>
+                )}
+              </For>
+            </div>
+          </div>
+        )}
+      </Show>
+
       {/* ------------------------------------------------------------------ */}
       {/* Timezone panel                                                      */}
       {/* ------------------------------------------------------------------ */}
@@ -317,7 +381,6 @@ export default function TimestampTool() {
                       "align-items": "center",
                     }}
                   >
-                    {/* Zone selector */}
                     <select
                       value={zone.tz}
                       onChange={(e) => changeZone(i(), e.currentTarget.value)}
@@ -337,7 +400,6 @@ export default function TimestampTool() {
                       </For>
                     </select>
 
-                    {/* Formatted time */}
                     <code
                       style={{
                         "font-size": "0.875rem",


### PR DESCRIPTION
## Summary
Harden the current local-only tool suite before the tool-page redesign wave. This PR adds pure parser/transform coverage in `src/lib/*`, improves recovery and output behavior for existing tools, and keeps the UI layer thin by wiring components to richer typed logic instead of embedding workflow rules in the views.

## Issue coverage
- #135 — partially addressed: this PR completes the current hardening slice for cron, Base64, hash, JSON, JWT, and timestamp logic ahead of the broader redesign wave.
- #132 — fully addressed: adds a pure local cron parser and validation core for the supported five-field syntax.
- #114 — fully addressed: lets decoded Base64 binary output be downloaded locally.
- #115 — fully addressed: adds local file hashing through the shared import flow.
- #116 — fully addressed: surfaces JSON parse locations plus nearby error context for invalid input.
- #117 — fully addressed: adds stable key sorting to the JSON formatter.
- #118 — fully addressed: adds a claims summary for standard registered JWT fields.
- #119 — fully addressed: adds more derived timestamp output formats beyond Unix and ISO.

## Changes
- add a pure cron parser/validator core with typed five-field support for wildcards, values, ranges, lists, and steps
- let Base64 decode produce downloadable binary output, add local file hashing, and keep both file workflows on the shared import path
- extend the JSON formatter with recursive stable key sorting plus parse location/context hints for malformed input
- add registered JWT claim summaries and broaden timestamp outputs with additional derived date formats

## Testing
- [x] `bun run verify`
- [x] `bun run test src/lib/cron.test.ts`
- [x] confirm all new behavior is implemented through `src/lib/*` helpers before tool UI wiring
- [ ] manually verify Base64 file round-trip and binary download
- [ ] manually verify hash parity between text and file inputs
- [ ] manually verify JWT claim summaries and timestamp derived outputs in the browser

## References
- Issue: #135 (partially addressed)
- Issue: #132 (fully addressed)
- Issue: #114 (fully addressed)
- Issue: #115 (fully addressed)
- Issue: #116 (fully addressed)
- Issue: #117 (fully addressed)
- Issue: #118 (fully addressed)
- Issue: #119 (fully addressed)
