### PR TITLE
feat(text): add a case converter

### DIFF
--- a/src/lib/caseConverter.test.ts
+++ b/src/lib/caseConverter.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { convertCaseVariants } from "./caseConverter";
+
+describe("convertCaseVariants", () => {
+  it("fans out a plain phrase into common case variants", () => {
+    expect(convertCaseVariants("hello world")).toEqual({
+      lowercase: "hello world",
+      uppercase: "HELLO WORLD",
+      camelCase: "helloWorld",
+      pascalCase: "HelloWorld",
+      snakeCase: "hello_world",
+      kebabCase: "hello-world",
+      constantCase: "HELLO_WORLD",
+      dotCase: "hello.world",
+      pathCase: "hello/world",
+      sentenceCase: "Hello world",
+      headerCase: "Hello-World",
+    });
+  });
+
+  it("normalizes punctuation-heavy and mixed-style input predictably", () => {
+    expect(convertCaseVariants("__hello-world.testValue HTTPStatus200!!")).toEqual({
+      lowercase: "hello world test value http status 200",
+      uppercase: "HELLO WORLD TEST VALUE HTTP STATUS 200",
+      camelCase: "helloWorldTestValueHttpStatus200",
+      pascalCase: "HelloWorldTestValueHttpStatus200",
+      snakeCase: "hello_world_test_value_http_status_200",
+      kebabCase: "hello-world-test-value-http-status-200",
+      constantCase: "HELLO_WORLD_TEST_VALUE_HTTP_STATUS_200",
+      dotCase: "hello.world.test.value.http.status.200",
+      pathCase: "hello/world/test/value/http/status/200",
+      sentenceCase: "Hello world test value http status 200",
+      headerCase: "Hello-World-Test-Value-Http-Status-200",
+    });
+  });
+
+  it("returns empty variants for empty input", () => {
+    expect(convertCaseVariants("   \n\t  ")).toEqual({
+      lowercase: "",
+      uppercase: "",
+      camelCase: "",
+      pascalCase: "",
+      snakeCase: "",
+      kebabCase: "",
+      constantCase: "",
+      dotCase: "",
+      pathCase: "",
+      sentenceCase: "",
+      headerCase: "",
+    });
+  });
+});

--- a/src/lib/caseConverter.ts
+++ b/src/lib/caseConverter.ts
@@ -1,0 +1,86 @@
+export interface CaseVariants {
+  lowercase: string;
+  uppercase: string;
+  camelCase: string;
+  pascalCase: string;
+  snakeCase: string;
+  kebabCase: string;
+  constantCase: string;
+  dotCase: string;
+  pathCase: string;
+  sentenceCase: string;
+  headerCase: string;
+}
+
+function splitIntoWords(input: string): string[] {
+  const normalized = input
+    .replace(/([\p{Ll}\p{Nd}])([\p{Lu}])/gu, "$1 $2")
+    .replace(/([\p{Lu}])(\p{Lu}[\p{Ll}])/gu, "$1 $2")
+    .replace(/([\p{L}])(\p{Nd})/gu, "$1 $2")
+    .replace(/(\p{Nd})(\p{L})/gu, "$1 $2")
+    .replace(/[^\p{L}\p{Nd}]+/gu, " ")
+    .trim();
+
+  if (normalized.length === 0) {
+    return [];
+  }
+
+  return normalized
+    .split(/\s+/)
+    .map((word) => word.toLocaleLowerCase())
+    .filter((word) => word.length > 0);
+}
+
+function capitalize(word: string): string {
+  return word.length === 0 ? word : `${word[0].toLocaleUpperCase()}${word.slice(1)}`;
+}
+
+function joinWords(words: string[], separator: string): string {
+  return words.join(separator);
+}
+
+function buildCamelCase(words: string[]): string {
+  const [first = "", ...rest] = words;
+  return `${first}${rest.map(capitalize).join("")}`;
+}
+
+function buildPascalCase(words: string[]): string {
+  return words.map(capitalize).join("");
+}
+
+export function convertCaseVariants(input: string): CaseVariants {
+  const words = splitIntoWords(input);
+
+  if (words.length === 0) {
+    return {
+      lowercase: "",
+      uppercase: "",
+      camelCase: "",
+      pascalCase: "",
+      snakeCase: "",
+      kebabCase: "",
+      constantCase: "",
+      dotCase: "",
+      pathCase: "",
+      sentenceCase: "",
+      headerCase: "",
+    };
+  }
+
+  const lowercase = joinWords(words, " ");
+  const uppercase = lowercase.toLocaleUpperCase();
+
+  return {
+    lowercase,
+    uppercase,
+    camelCase: buildCamelCase(words),
+    pascalCase: buildPascalCase(words),
+    snakeCase: joinWords(words, "_"),
+    kebabCase: joinWords(words, "-"),
+    constantCase: joinWords(words, "_").toLocaleUpperCase(),
+    dotCase: joinWords(words, "."),
+    pathCase: joinWords(words, "/"),
+    sentenceCase: `${capitalize(words[0])}${words.length > 1 ? ` ${words.slice(1).join(" ")}` : ""}`,
+    headerCase: words.map(capitalize).join("-"),
+  };
+}

--- a/src/tools/case-converter/CaseConverter.tsx
+++ b/src/tools/case-converter/CaseConverter.tsx
@@ -1,0 +1,131 @@
+import { createMemo, createSignal, For, Show } from "solid-js";
+
+import CopyButton from "@/components/CopyButton";
+import ToolStatusMessage from "@/components/ToolStatusMessage";
+import { convertCaseVariants } from "@/lib/caseConverter";
+
+const VARIANT_LABELS = [
+  ["lowercase", "lowercase"],
+  ["uppercase", "UPPERCASE"],
+  ["camelCase", "camelCase"],
+  ["pascalCase", "PascalCase"],
+  ["snakeCase", "snake_case"],
+  ["kebabCase", "kebab-case"],
+  ["constantCase", "CONSTANT_CASE"],
+  ["dotCase", "dot.case"],
+  ["pathCase", "path/case"],
+  ["sentenceCase", "Sentence case"],
+  ["headerCase", "Header-Case"],
+] as const satisfies ReadonlyArray<readonly [keyof ReturnType<typeof convertCaseVariants>, string]>;
+
+export default function CaseConverter() {
+  const [input, setInput] = createSignal("");
+  const variants = createMemo(() => convertCaseVariants(input()));
+  const hasInput = createMemo(() => input().trim().length > 0);
+
+  const labelStyle = {
+    "font-size": "0.75rem",
+    "font-weight": "600" as const,
+    "letter-spacing": "0.05em",
+    "text-transform": "uppercase" as const,
+    color: "var(--text-secondary)",
+  };
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        "flex-direction": "column",
+        gap: "1.25rem",
+        padding: "1.5rem",
+        "max-width": "900px",
+        margin: "0 auto",
+        width: "100%",
+      }}
+    >
+      <div style={{ display: "flex", "flex-direction": "column", gap: "0.375rem" }}>
+        <label style={labelStyle}>Source text</label>
+        <textarea
+          value={input()}
+          onInput={(event) => setInput(event.currentTarget.value)}
+          placeholder="Paste text, identifiers, or titles to fan out into multiple case styles…"
+          rows={6}
+          spellcheck={false}
+          style={{
+            width: "100%",
+            padding: "0.875rem 1rem",
+            "border-radius": "0.5rem",
+            border: "1px solid var(--border)",
+            background: "var(--bg-secondary)",
+            color: "var(--text-primary)",
+            "font-family": "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+            "font-size": "0.875rem",
+            "line-height": "1.6",
+            resize: "vertical",
+            outline: "none",
+            "box-sizing": "border-box",
+          }}
+        />
+      </div>
+
+      <Show
+        when={hasInput()}
+        fallback={
+          <ToolStatusMessage tone="muted">
+            Enter text once to generate copyable case variants locally.
+          </ToolStatusMessage>
+        }
+      >
+        <div
+          style={{
+            display: "grid",
+            gap: "0.75rem",
+            "grid-template-columns": "repeat(auto-fit, minmax(240px, 1fr))",
+          }}
+        >
+          <For each={VARIANT_LABELS}>
+            {([key, label]) => (
+              <section
+                style={{
+                  display: "flex",
+                  "flex-direction": "column",
+                  gap: "0.5rem",
+                  padding: "0.875rem",
+                  background: "var(--bg-secondary)",
+                  border: "1px solid var(--border)",
+                  "border-radius": "0.5rem",
+                }}
+              >
+                <div
+                  style={{
+                    display: "flex",
+                    "align-items": "center",
+                    "justify-content": "space-between",
+                    gap: "0.75rem",
+                  }}
+                >
+                  <span style={labelStyle}>{label}</span>
+                  <CopyButton text={variants()[key]} label={`Copy ${label}`} />
+                </div>
+                <code
+                  style={{
+                    margin: "0",
+                    color: "var(--text-primary)",
+                    "font-size": "0.875rem",
+                    "line-height": "1.7",
+                    "font-family":
+                      "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+                    "white-space": "pre-wrap",
+                    "word-break": "break-word",
+                  }}
+                >
+                  {variants()[key] || "—"}
+                </code>
+              </section>
+            )}
+          </For>
+        </div>
+      </Show>
+    </div>
+  );
+}

--- a/src/tools/registry.test.ts
+++ b/src/tools/registry.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { tools, validateToolRegistry } from "./registry";
+import { getToolBySlug, tools, validateToolRegistry } from "./registry";
 
 const toolComponentPaths = tools.map((tool) => tool.componentPath);
 
@@ -15,5 +15,13 @@ describe("tool registry", () => {
         `/src/tools/${tool.slug}/${tool.componentPath.split("/").at(-1)}`
       );
     }
+  });
+
+  it("includes the case converter route", () => {
+    expect(getToolBySlug("case-converter")).toMatchObject({
+      id: "case-converter",
+      category: "text",
+      componentPath: "/src/tools/case-converter/CaseConverter.tsx",
+    });
   });
 });

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -100,6 +100,16 @@ export const tools: Tool[] = [
     slug: "regex-tester",
     componentPath: "/src/tools/regex-tester/RegexTester.tsx",
   },
+  {
+    id: "case-converter",
+    name: "Case Converter",
+    description: "Fan out one input into common case styles for code, paths, and titles.",
+    category: "text",
+    keywords: ["case", "camel", "pascal", "snake", "kebab", "header", "convert", "text"],
+    icon: "CaseSensitive",
+    slug: "case-converter",
+    componentPath: "/src/tools/case-converter/CaseConverter.tsx",
+  },
 ];
 
 export function getToolRoute(slug: string): `/tools/${string}` {


### PR DESCRIPTION
## Summary
Add a local-only case converter with pure conversion helpers in `src/lib/*` and a thin UI that fans one input out into common identifier, title, and path casing variants. The implementation keeps all conversion logic client-side, handles empty and punctuation-heavy input predictably, and wires the tool through the shared registry.

## Issue coverage
- #120 — fully addressed: adds the case converter tool, pure helper coverage, and route registration.

## Changes
- add `convertCaseVariants(...)` with support for lowercase, uppercase, camelCase, PascalCase, snake_case, kebab-case, CONSTANT_CASE, dot.case, path/case, sentence case, and Header-Case
- add a new `case-converter` tool with copyable outputs for each generated variant
- extend registry coverage with a route smoke assertion for the new tool

## Testing
- [x] `bun run test src/lib/caseConverter.test.ts src/tools/registry.test.ts`
- [x] `bun run verify`
- [ ] manually verify common identifier and title-case conversions in the browser
- [ ] manually verify punctuation-heavy input fan-out and copy actions

## References
- Closes #120
