### PR TITLE
feat(text): add a text statistics tool

### DIFF
--- a/src/lib/textStatistics.test.ts
+++ b/src/lib/textStatistics.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { analyzeText } from "./textStatistics";
+
+describe("analyzeText", () => {
+  it("reports zero-like metrics for empty input", () => {
+    expect(analyzeText("")).toEqual({
+      characters: 0,
+      words: 0,
+      lines: 0,
+      bytes: 0,
+    });
+  });
+
+  it("counts representative whitespace and multiline input", () => {
+    expect(analyzeText("Hello world\nTwo  spaces\n\nlast line")).toEqual({
+      characters: 34,
+      words: 6,
+      lines: 4,
+      bytes: 34,
+    });
+  });
+
+  it("computes byte size from the encoded string for unicode-heavy input", () => {
+    expect(analyzeText("héllo 👋\n世界")).toEqual({
+      characters: 10,
+      words: 3,
+      lines: 2,
+      bytes: 18,
+    });
+  });
+});

--- a/src/lib/textStatistics.ts
+++ b/src/lib/textStatistics.ts
@@ -1,0 +1,28 @@
+export interface TextStatistics {
+  characters: number;
+  words: number;
+  lines: number;
+  bytes: number;
+}
+
+function countWords(input: string): number {
+  const trimmed = input.trim();
+  return trimmed.length === 0 ? 0 : trimmed.split(/\s+/u).length;
+}
+
+function countLines(input: string): number {
+  if (input.length === 0) {
+    return 0;
+  }
+
+  return input.replace(/\r\n?/g, "\n").split("\n").length;
+}
+
+export function analyzeText(input: string): TextStatistics {
+  return {
+    characters: Array.from(input).length,
+    words: countWords(input),
+    lines: countLines(input),
+    bytes: new TextEncoder().encode(input).length,
+  };
+}

--- a/src/tools/registry.test.ts
+++ b/src/tools/registry.test.ts
@@ -24,4 +24,12 @@ describe("tool registry", () => {
       componentPath: "/src/tools/case-converter/CaseConverter.tsx",
     });
   });
+
+  it("includes the text statistics route", () => {
+    expect(getToolBySlug("text-statistics")).toMatchObject({
+      id: "text-statistics",
+      category: "text",
+      componentPath: "/src/tools/text-statistics/TextStatisticsTool.tsx",
+    });
+  });
 });

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -110,6 +110,16 @@ export const tools: Tool[] = [
     slug: "case-converter",
     componentPath: "/src/tools/case-converter/CaseConverter.tsx",
   },
+  {
+    id: "text-statistics",
+    name: "Text Statistics",
+    description: "Inspect character, word, line, and byte counts for local text input.",
+    category: "text",
+    keywords: ["text", "statistics", "count", "words", "lines", "bytes", "characters"],
+    icon: "TextCursorInput",
+    slug: "text-statistics",
+    componentPath: "/src/tools/text-statistics/TextStatisticsTool.tsx",
+  },
 ];
 
 export function getToolRoute(slug: string): `/tools/${string}` {

--- a/src/tools/text-statistics/TextStatisticsTool.tsx
+++ b/src/tools/text-statistics/TextStatisticsTool.tsx
@@ -1,0 +1,102 @@
+import { createMemo, createSignal, For } from "solid-js";
+
+import ToolStatusMessage from "@/components/ToolStatusMessage";
+import { analyzeText } from "@/lib/textStatistics";
+
+const METRIC_LABELS = [
+  ["characters", "Characters"],
+  ["words", "Words"],
+  ["lines", "Lines"],
+  ["bytes", "Bytes"],
+] as const satisfies ReadonlyArray<readonly [keyof ReturnType<typeof analyzeText>, string]>;
+
+export default function TextStatisticsTool() {
+  const [input, setInput] = createSignal("");
+  const statistics = createMemo(() => analyzeText(input()));
+
+  const labelStyle = {
+    "font-size": "0.75rem",
+    "font-weight": "600" as const,
+    "letter-spacing": "0.05em",
+    "text-transform": "uppercase" as const,
+    color: "var(--text-secondary)",
+  };
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        "flex-direction": "column",
+        gap: "1.25rem",
+        padding: "1.5rem",
+        "max-width": "900px",
+        margin: "0 auto",
+        width: "100%",
+      }}
+    >
+      <div style={{ display: "flex", "flex-direction": "column", gap: "0.375rem" }}>
+        <label style={labelStyle}>Text input</label>
+        <textarea
+          value={input()}
+          onInput={(event) => setInput(event.currentTarget.value)}
+          placeholder="Type or paste text to inspect its raw size and structure locally…"
+          rows={10}
+          spellcheck={false}
+          style={{
+            width: "100%",
+            padding: "0.875rem 1rem",
+            "border-radius": "0.5rem",
+            border: "1px solid var(--border)",
+            background: "var(--bg-secondary)",
+            color: "var(--text-primary)",
+            "font-family": "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+            "font-size": "0.875rem",
+            "line-height": "1.6",
+            resize: "vertical",
+            outline: "none",
+            "box-sizing": "border-box",
+          }}
+        />
+      </div>
+
+      <div
+        style={{
+          display: "grid",
+          gap: "0.75rem",
+          "grid-template-columns": "repeat(auto-fit, minmax(180px, 1fr))",
+        }}
+      >
+        <For each={METRIC_LABELS}>
+          {([key, label]) => (
+            <section
+              style={{
+                display: "flex",
+                "flex-direction": "column",
+                gap: "0.375rem",
+                padding: "0.875rem",
+                background: "var(--bg-secondary)",
+                border: "1px solid var(--border)",
+                "border-radius": "0.5rem",
+              }}
+            >
+              <span style={labelStyle}>{label}</span>
+              <strong
+                style={{
+                  color: "var(--text-primary)",
+                  "font-size": "1.625rem",
+                  "line-height": "1.2",
+                }}
+              >
+                {statistics()[key].toLocaleString()}
+              </strong>
+            </section>
+          )}
+        </For>
+      </div>
+
+      <ToolStatusMessage tone="muted">
+        Counts update locally as you type. Byte size is measured from the encoded UTF-8 text.
+      </ToolStatusMessage>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Add a local-only text statistics tool with pure counting helpers in `src/lib/*` and a thin UI that updates live as text changes. The implementation keeps all metrics client-side, counts UTF-8 bytes from the encoded string, and registers the new route through the shared tool registry.

## Issue coverage
- #121 — fully addressed: adds the text statistics tool, pure helper coverage, and route registration.

## Changes
- add `analyzeText(...)` to derive character, word, line, and byte counts from raw input
- add a `text-statistics` tool that reports live metrics for pasted or typed text
- extend registry coverage with a route smoke assertion for the new tool

## Testing
- [x] `bun run test src/lib/textStatistics.test.ts src/tools/registry.test.ts`
- [x] `bun run verify`
- [ ] manually verify multiline and Unicode-heavy input in the browser

## References
- Closes #121
