### PR TITLE
feat(generators): add a configurable random token generator

### DIFF
--- a/src/lib/tokenGenerator.test.ts
+++ b/src/lib/tokenGenerator.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_TOKEN_OPTIONS, generateToken, normalizeTokenOptions } from "./tokenGenerator";
+
+describe("normalizeTokenOptions", () => {
+  it("clamps token length into the supported range", () => {
+    expect(normalizeTokenOptions({ ...DEFAULT_TOKEN_OPTIONS, length: 0 }).length).toBe(1);
+    expect(normalizeTokenOptions({ ...DEFAULT_TOKEN_OPTIONS, length: 999 }).length).toBe(512);
+  });
+});
+
+describe("generateToken", () => {
+  it("returns a clear validation error when all character sets are disabled", () => {
+    expect(
+      generateToken({
+        length: 16,
+        uppercase: false,
+        lowercase: false,
+        digits: false,
+        symbols: false,
+      })
+    ).toEqual({
+      ok: false,
+      error: "Select at least one character set.",
+    });
+  });
+
+  it("uses the requested character sets only", () => {
+    const result = generateToken(
+      {
+        length: 8,
+        uppercase: false,
+        lowercase: true,
+        digits: true,
+        symbols: false,
+      },
+      (length) => Uint8Array.from([0, 25, 26, 35, 36, 61, 70, 251].slice(0, length))
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      token: "az09az89",
+      alphabet: "abcdefghijklmnopqrstuvwxyz0123456789",
+    });
+  });
+
+  it("retries bytes that would introduce modulo bias", () => {
+    const calls: number[] = [];
+    const result = generateToken(
+      {
+        length: 4,
+        uppercase: false,
+        lowercase: false,
+        digits: false,
+        symbols: true,
+      },
+      (length) => {
+        calls.push(length);
+        return calls.length === 1 ? Uint8Array.from([0, 1, 250, 251]) : Uint8Array.from([2, 3]);
+      }
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      token: '!"#$',
+      alphabet: '!"#$%&()*+,-./:;<=>?@[\\]^_{|}~',
+    });
+    expect(calls).toEqual([4, 2]);
+  });
+});

--- a/src/lib/tokenGenerator.ts
+++ b/src/lib/tokenGenerator.ts
@@ -1,0 +1,107 @@
+export interface TokenGeneratorOptions {
+  length: number;
+  uppercase: boolean;
+  lowercase: boolean;
+  digits: boolean;
+  symbols: boolean;
+}
+
+export interface TokenGenerationSuccess {
+  ok: true;
+  token: string;
+  alphabet: string;
+}
+
+export interface TokenGenerationFailure {
+  ok: false;
+  error: string;
+}
+
+export type TokenGenerationResult = TokenGenerationSuccess | TokenGenerationFailure;
+export type RandomByteSource = (length: number) => Uint8Array;
+
+export const MIN_TOKEN_LENGTH = 1;
+export const MAX_TOKEN_LENGTH = 512;
+export const SYMBOL_ALPHABET = '!"#$%&()*+,-./:;<=>?@[\\]^_{|}~';
+
+export const DEFAULT_TOKEN_OPTIONS: TokenGeneratorOptions = {
+  length: 32,
+  uppercase: true,
+  lowercase: true,
+  digits: true,
+  symbols: false,
+};
+
+function defaultRandomBytes(length: number): Uint8Array {
+  return crypto.getRandomValues(new Uint8Array(length));
+}
+
+export function normalizeTokenOptions(options: TokenGeneratorOptions): TokenGeneratorOptions {
+  return {
+    ...options,
+    length: Math.min(MAX_TOKEN_LENGTH, Math.max(MIN_TOKEN_LENGTH, Math.trunc(options.length) || 1)),
+  };
+}
+
+export function buildTokenAlphabet(options: TokenGeneratorOptions): string {
+  let alphabet = "";
+
+  if (options.uppercase) {
+    alphabet += "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+  }
+
+  if (options.lowercase) {
+    alphabet += "abcdefghijklmnopqrstuvwxyz";
+  }
+
+  if (options.digits) {
+    alphabet += "0123456789";
+  }
+
+  if (options.symbols) {
+    alphabet += SYMBOL_ALPHABET;
+  }
+
+  return alphabet;
+}
+
+export function generateToken(
+  input: TokenGeneratorOptions,
+  randomBytes: RandomByteSource = defaultRandomBytes
+): TokenGenerationResult {
+  const options = normalizeTokenOptions(input);
+  const alphabet = buildTokenAlphabet(options);
+
+  if (alphabet.length === 0) {
+    return {
+      ok: false,
+      error: "Select at least one character set.",
+    };
+  }
+
+  const limit = Math.floor(256 / alphabet.length) * alphabet.length;
+  let token = "";
+
+  while (token.length < options.length) {
+    const remaining = options.length - token.length;
+    const bytes = randomBytes(remaining);
+
+    for (const byte of bytes) {
+      if (byte >= limit) {
+        continue;
+      }
+
+      token += alphabet[byte % alphabet.length];
+
+      if (token.length === options.length) {
+        break;
+      }
+    }
+  }
+
+  return {
+    ok: true,
+    token,
+    alphabet,
+  };
+}

--- a/src/tools/registry.test.ts
+++ b/src/tools/registry.test.ts
@@ -32,4 +32,12 @@ describe("tool registry", () => {
       componentPath: "/src/tools/text-statistics/TextStatisticsTool.tsx",
     });
   });
+
+  it("includes the token generator route", () => {
+    expect(getToolBySlug("token-generator")).toMatchObject({
+      id: "token-generator",
+      category: "generators",
+      componentPath: "/src/tools/token-generator/TokenGenerator.tsx",
+    });
+  });
 });

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -120,6 +120,16 @@ export const tools: Tool[] = [
     slug: "text-statistics",
     componentPath: "/src/tools/text-statistics/TextStatisticsTool.tsx",
   },
+  {
+    id: "token-generator",
+    name: "Token Generator",
+    description: "Generate configurable random tokens with browser-local cryptography.",
+    category: "generators",
+    keywords: ["token", "password", "random", "generate", "crypto", "secret"],
+    icon: "KeySquare",
+    slug: "token-generator",
+    componentPath: "/src/tools/token-generator/TokenGenerator.tsx",
+  },
 ];
 
 export function getToolRoute(slug: string): `/tools/${string}` {

--- a/src/tools/token-generator/TokenGenerator.tsx
+++ b/src/tools/token-generator/TokenGenerator.tsx
@@ -1,0 +1,182 @@
+import { createMemo, createSignal, Show } from "solid-js";
+
+import CopyButton from "@/components/CopyButton";
+import ToolActionButton from "@/components/ToolActionButton";
+import ToolStatusMessage from "@/components/ToolStatusMessage";
+import {
+  DEFAULT_TOKEN_OPTIONS,
+  generateToken,
+  MAX_TOKEN_LENGTH,
+  MIN_TOKEN_LENGTH,
+  type TokenGeneratorOptions,
+} from "@/lib/tokenGenerator";
+
+function createInitialState() {
+  const result = generateToken(DEFAULT_TOKEN_OPTIONS);
+  return {
+    token: result.ok ? result.token : "",
+    error: result.ok ? "" : result.error,
+  };
+}
+
+export default function TokenGenerator() {
+  const initial = createInitialState();
+  const [options, setOptions] = createSignal<TokenGeneratorOptions>(DEFAULT_TOKEN_OPTIONS);
+  const [token, setToken] = createSignal(initial.token);
+  const [error, setError] = createSignal(initial.error);
+
+  const labelStyle = {
+    "font-size": "0.75rem",
+    "font-weight": "600" as const,
+    "letter-spacing": "0.05em",
+    "text-transform": "uppercase" as const,
+    color: "var(--text-secondary)",
+  };
+
+  const activeGroups = createMemo(() => {
+    const current = options();
+    return [
+      current.uppercase && "uppercase",
+      current.lowercase && "lowercase",
+      current.digits && "digits",
+      current.symbols && "symbols",
+    ].filter(Boolean);
+  });
+
+  function regenerate(nextOptions: TokenGeneratorOptions = options()) {
+    const result = generateToken(nextOptions);
+    if (result.ok) {
+      setToken(result.token);
+      setError("");
+      return;
+    }
+
+    setToken("");
+    setError(result.error);
+  }
+
+  function updateOption<K extends keyof TokenGeneratorOptions>(
+    key: K,
+    value: TokenGeneratorOptions[K]
+  ) {
+    setOptions((current) => {
+      const next = { ...current, [key]: value };
+      regenerate(next);
+      return next;
+    });
+  }
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        "flex-direction": "column",
+        gap: "1.25rem",
+        padding: "1.5rem",
+        "max-width": "900px",
+        margin: "0 auto",
+        width: "100%",
+      }}
+    >
+      <div style={{ display: "grid", gap: "1rem", "grid-template-columns": "2fr 1fr" }}>
+        <div
+          style={{
+            display: "flex",
+            "flex-direction": "column",
+            gap: "0.375rem",
+            padding: "0.875rem",
+            background: "var(--bg-secondary)",
+            border: "1px solid var(--border)",
+            "border-radius": "0.5rem",
+          }}
+        >
+          <div style={{ display: "flex", "justify-content": "space-between", gap: "0.75rem" }}>
+            <span style={labelStyle}>Generated token</span>
+            <CopyButton text={token()} label="Copy token" />
+          </div>
+          <code
+            style={{
+              color: "var(--text-primary)",
+              "font-size": "1rem",
+              "line-height": "1.7",
+              "font-family": "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+              "word-break": "break-all",
+              "min-height": "4.5rem",
+            }}
+          >
+            {token() || "—"}
+          </code>
+        </div>
+
+        <div
+          style={{
+            display: "flex",
+            "flex-direction": "column",
+            gap: "0.375rem",
+            padding: "0.875rem",
+            background: "var(--bg-secondary)",
+            border: "1px solid var(--border)",
+            "border-radius": "0.5rem",
+          }}
+        >
+          <span style={labelStyle}>Options</span>
+          <label style={{ color: "var(--text-secondary)", "font-size": "0.875rem" }}>Length</label>
+          <input
+            type="number"
+            min={MIN_TOKEN_LENGTH}
+            max={MAX_TOKEN_LENGTH}
+            value={options().length}
+            onInput={(event) => updateOption("length", Number(event.currentTarget.value) || 0)}
+            style={{
+              width: "100%",
+              padding: "0.625rem 0.75rem",
+              border: "1px solid var(--border)",
+              "border-radius": "0.5rem",
+              background: "var(--bg-primary)",
+              color: "var(--text-primary)",
+            }}
+          />
+          <ToolActionButton onClick={() => regenerate()} variant="primary">
+            Regenerate
+          </ToolActionButton>
+        </div>
+      </div>
+
+      <div style={{ display: "flex", gap: "0.5rem", "flex-wrap": "wrap" }}>
+        <ToolActionButton
+          active={options().uppercase}
+          onClick={() => updateOption("uppercase", !options().uppercase)}
+        >
+          Uppercase
+        </ToolActionButton>
+        <ToolActionButton
+          active={options().lowercase}
+          onClick={() => updateOption("lowercase", !options().lowercase)}
+        >
+          Lowercase
+        </ToolActionButton>
+        <ToolActionButton
+          active={options().digits}
+          onClick={() => updateOption("digits", !options().digits)}
+        >
+          Digits
+        </ToolActionButton>
+        <ToolActionButton
+          active={options().symbols}
+          onClick={() => updateOption("symbols", !options().symbols)}
+        >
+          Symbols
+        </ToolActionButton>
+      </div>
+
+      <Show when={error()}>
+        {(message) => <ToolStatusMessage tone="error">{message()}</ToolStatusMessage>}
+      </Show>
+
+      <ToolStatusMessage tone="muted">
+        Uses <code>crypto.getRandomValues()</code> locally with {activeGroups().length || "no"}{" "}
+        character set{activeGroups().length === 1 ? "" : "s"} enabled.
+      </ToolStatusMessage>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Add a local-only token generator with pure option handling and random-token generation logic in `src/lib/*`, then keep the UI thin around those helpers. The tool uses browser cryptography, handles invalid character-set combinations clearly, and registers the new route through the shared registry.

## Issue coverage
- #122 — fully addressed: adds the configurable token generator, pure helper coverage, and route registration.

## Changes
- add token-generation helpers with configurable length, character-set selection, length normalization, and modulo-bias avoidance
- add a `token-generator` tool with regenerate, copy, and validation feedback flows
- extend registry coverage with a route smoke assertion for the new tool

## Testing
- [x] `bun run test src/lib/tokenGenerator.test.ts src/tools/registry.test.ts`
- [x] `bun run verify`
- [ ] manually verify multiple character-set combinations and length changes in the browser

## References
- Closes #122
