### PR TITLE
feat(encoding): add a URL encoder and decoder

### DIFF
--- a/src/lib/urlEncoding.test.ts
+++ b/src/lib/urlEncoding.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { decodeUrlText, encodeUrlText } from "./urlEncoding";
+
+describe("encodeUrlText", () => {
+  it("percent-encodes representative spaces, unicode, and reserved characters", () => {
+    expect(encodeUrlText("hello world/π?test=1&ok=true")).toBe(
+      "hello%20world%2F%CF%80%3Ftest%3D1%26ok%3Dtrue"
+    );
+  });
+});
+
+describe("decodeUrlText", () => {
+  it("decodes representative percent-encoded input", () => {
+    expect(decodeUrlText("hello%20world%2F%CF%80%3Ftest%3D1%26ok%3Dtrue")).toEqual({
+      ok: true,
+      value: "hello world/π?test=1&ok=true",
+    });
+  });
+
+  it("surfaces a clear error for malformed percent sequences", () => {
+    expect(decodeUrlText("hello%2Gworld%")).toEqual({
+      ok: false,
+      error: "Invalid percent-encoded input.",
+    });
+  });
+});

--- a/src/lib/urlEncoding.ts
+++ b/src/lib/urlEncoding.ts
@@ -1,0 +1,27 @@
+export type UrlDecodeResult =
+  | {
+      ok: true;
+      value: string;
+    }
+  | {
+      ok: false;
+      error: string;
+    };
+
+export function encodeUrlText(input: string): string {
+  return encodeURIComponent(input);
+}
+
+export function decodeUrlText(input: string): UrlDecodeResult {
+  try {
+    return {
+      ok: true,
+      value: decodeURIComponent(input),
+    };
+  } catch {
+    return {
+      ok: false,
+      error: "Invalid percent-encoded input.",
+    };
+  }
+}

--- a/src/tools/registry.test.ts
+++ b/src/tools/registry.test.ts
@@ -40,4 +40,12 @@ describe("tool registry", () => {
       componentPath: "/src/tools/token-generator/TokenGenerator.tsx",
     });
   });
+
+  it("includes the URL encoder route", () => {
+    expect(getToolBySlug("url-encoder")).toMatchObject({
+      id: "url-encoder",
+      category: "encoding",
+      componentPath: "/src/tools/url-encoder/UrlEncoderTool.tsx",
+    });
+  });
 });

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -130,6 +130,16 @@ export const tools: Tool[] = [
     slug: "token-generator",
     componentPath: "/src/tools/token-generator/TokenGenerator.tsx",
   },
+  {
+    id: "url-encoder",
+    name: "URL Encoder / Decoder",
+    description: "Percent-encode or decode text locally with clear invalid-input feedback.",
+    category: "encoding",
+    keywords: ["url", "encode", "decode", "percent", "uri", "query"],
+    icon: "Link2",
+    slug: "url-encoder",
+    componentPath: "/src/tools/url-encoder/UrlEncoderTool.tsx",
+  },
 ];
 
 export function getToolRoute(slug: string): `/tools/${string}` {

--- a/src/tools/url-encoder/UrlEncoderTool.tsx
+++ b/src/tools/url-encoder/UrlEncoderTool.tsx
@@ -1,0 +1,172 @@
+import { createMemo, createSignal, Show } from "solid-js";
+
+import CopyButton from "@/components/CopyButton";
+import ToolStatusMessage from "@/components/ToolStatusMessage";
+import { decodeUrlText, encodeUrlText } from "@/lib/urlEncoding";
+
+export default function UrlEncoderTool() {
+  const [plainText, setPlainText] = createSignal("");
+  const [encodedText, setEncodedText] = createSignal("");
+
+  const encodedOutput = createMemo(() => encodeUrlText(plainText()));
+  const decodedOutput = createMemo(() => decodeUrlText(encodedText()));
+  const decodedValue = createMemo(() => {
+    const current = decodedOutput();
+    return current.ok ? current.value : "";
+  });
+  const decodeError = createMemo(() => {
+    const current = decodedOutput();
+    return current.ok ? "" : current.error;
+  });
+
+  const labelStyle = {
+    "font-size": "0.75rem",
+    "font-weight": "600" as const,
+    "letter-spacing": "0.05em",
+    "text-transform": "uppercase" as const,
+    color: "var(--text-secondary)",
+  };
+
+  return (
+    <div
+      style={{
+        display: "grid",
+        gap: "1.25rem",
+        padding: "1.5rem",
+        "max-width": "1100px",
+        margin: "0 auto",
+        width: "100%",
+        "grid-template-columns": "repeat(auto-fit, minmax(320px, 1fr))",
+      }}
+    >
+      <section
+        style={{
+          display: "flex",
+          "flex-direction": "column",
+          gap: "1rem",
+          padding: "1rem",
+          background: "var(--bg-secondary)",
+          border: "1px solid var(--border)",
+          "border-radius": "0.75rem",
+        }}
+      >
+        <div style={{ display: "flex", "flex-direction": "column", gap: "0.375rem" }}>
+          <label style={labelStyle}>Plain text</label>
+          <textarea
+            value={plainText()}
+            onInput={(event) => setPlainText(event.currentTarget.value)}
+            placeholder="Enter text to percent-encode…"
+            rows={7}
+            spellcheck={false}
+            style={{
+              width: "100%",
+              padding: "0.875rem 1rem",
+              "border-radius": "0.5rem",
+              border: "1px solid var(--border)",
+              background: "var(--bg-primary)",
+              color: "var(--text-primary)",
+              "font-family": "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+              "font-size": "0.875rem",
+              "line-height": "1.6",
+              resize: "vertical",
+              outline: "none",
+              "box-sizing": "border-box",
+            }}
+          />
+        </div>
+
+        <div
+          style={{ display: "flex", "align-items": "center", "justify-content": "space-between" }}
+        >
+          <span style={labelStyle}>Encoded output</span>
+          <CopyButton text={encodedOutput()} label="Copy encoded" />
+        </div>
+        <pre
+          style={{
+            margin: "0",
+            padding: "0.875rem 1rem",
+            "border-radius": "0.5rem",
+            border: "1px solid var(--border)",
+            background: "var(--bg-primary)",
+            color: "var(--text-primary)",
+            "font-family": "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+            "font-size": "0.875rem",
+            "line-height": "1.7",
+            "min-height": "7rem",
+            "white-space": "pre-wrap",
+            "word-break": "break-all",
+          }}
+        >
+          {encodedOutput() || "—"}
+        </pre>
+      </section>
+
+      <section
+        style={{
+          display: "flex",
+          "flex-direction": "column",
+          gap: "1rem",
+          padding: "1rem",
+          background: "var(--bg-secondary)",
+          border: "1px solid var(--border)",
+          "border-radius": "0.75rem",
+        }}
+      >
+        <div style={{ display: "flex", "flex-direction": "column", gap: "0.375rem" }}>
+          <label style={labelStyle}>Percent-encoded text</label>
+          <textarea
+            value={encodedText()}
+            onInput={(event) => setEncodedText(event.currentTarget.value)}
+            placeholder="Enter percent-encoded text to decode…"
+            rows={7}
+            spellcheck={false}
+            style={{
+              width: "100%",
+              padding: "0.875rem 1rem",
+              "border-radius": "0.5rem",
+              border: `1px solid ${decodeError() ? "var(--accent-error)" : "var(--border)"}`,
+              background: "var(--bg-primary)",
+              color: "var(--text-primary)",
+              "font-family": "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+              "font-size": "0.875rem",
+              "line-height": "1.6",
+              resize: "vertical",
+              outline: "none",
+              "box-sizing": "border-box",
+            }}
+          />
+        </div>
+
+        <Show
+          when={!decodeError()}
+          fallback={<ToolStatusMessage tone="error">{decodeError()}</ToolStatusMessage>}
+        >
+          <div
+            style={{ display: "flex", "align-items": "center", "justify-content": "space-between" }}
+          >
+            <span style={labelStyle}>Decoded output</span>
+            <CopyButton text={decodedValue()} label="Copy decoded" />
+          </div>
+          <pre
+            style={{
+              margin: "0",
+              padding: "0.875rem 1rem",
+              "border-radius": "0.5rem",
+              border: "1px solid var(--border)",
+              background: "var(--bg-primary)",
+              color: "var(--text-primary)",
+              "font-family": "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+              "font-size": "0.875rem",
+              "line-height": "1.7",
+              "min-height": "7rem",
+              "white-space": "pre-wrap",
+              "word-break": "break-all",
+            }}
+          >
+            {decodedValue() || "—"}
+          </pre>
+        </Show>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Add a local-only URL encoder/decoder with pure percent-encoding helpers in `src/lib/*` and a thin two-pane UI around them. The tool keeps encode and decode flows independent, surfaces invalid decode input clearly, and registers the new route through the shared registry.

## Issue coverage
- #123 — fully addressed: adds the URL encoder/decoder, pure helper coverage, and route registration.

## Changes
- add pure URL percent-encoding helpers with explicit invalid-input handling for decode failures
- add a `url-encoder` tool with independent encode and decode panes plus copy actions for both outputs
- extend registry coverage with a route smoke assertion for the new tool

## Testing
- [x] `bun run test src/lib/urlEncoding.test.ts src/tools/registry.test.ts`
- [x] `bun run verify`
- [ ] manually verify spaces, Unicode, reserved characters, and malformed percent sequences in the browser

## References
- Closes #123
