### PR TITLE
feat(network): add an HTTP status code reference

### DIFF
--- a/src/lib/httpStatusCodes.test.ts
+++ b/src/lib/httpStatusCodes.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { HTTP_STATUS_CODES, searchHttpStatusCodes } from "./httpStatusCodes";
+
+describe("HTTP_STATUS_CODES", () => {
+  it("covers representative status classes", () => {
+    expect(HTTP_STATUS_CODES).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: 200, category: "Success", name: "OK" }),
+        expect.objectContaining({ code: 301, category: "Redirection", name: "Moved Permanently" }),
+        expect.objectContaining({ code: 404, category: "Client Error", name: "Not Found" }),
+        expect.objectContaining({
+          code: 422,
+          category: "Client Error",
+          name: "Unprocessable Content",
+        }),
+        expect.objectContaining({
+          code: 500,
+          category: "Server Error",
+          name: "Internal Server Error",
+        }),
+      ])
+    );
+  });
+});
+
+describe("searchHttpStatusCodes", () => {
+  it("finds entries by numeric code", () => {
+    expect(searchHttpStatusCodes("404").map((entry) => entry.code)).toContain(404);
+  });
+
+  it("finds entries by standard name", () => {
+    expect(searchHttpStatusCodes("unprocessable")).toEqual([
+      expect.objectContaining({ code: 422, name: "Unprocessable Content" }),
+    ]);
+  });
+
+  it("finds entries by category text", () => {
+    expect(
+      searchHttpStatusCodes("redirect").every((entry) => entry.category === "Redirection")
+    ).toBe(true);
+    expect(searchHttpStatusCodes("redirect").length).toBeGreaterThan(0);
+  });
+});

--- a/src/lib/httpStatusCodes.ts
+++ b/src/lib/httpStatusCodes.ts
@@ -1,0 +1,399 @@
+export type HttpStatusCategory =
+  | "Informational"
+  | "Success"
+  | "Redirection"
+  | "Client Error"
+  | "Server Error";
+
+export interface HttpStatusCodeEntry {
+  code: number;
+  name: string;
+  category: HttpStatusCategory;
+  description: string;
+}
+
+export const HTTP_STATUS_CODES: HttpStatusCodeEntry[] = [
+  {
+    code: 100,
+    name: "Continue",
+    category: "Informational",
+    description: "The initial part of the request was received and the client may continue.",
+  },
+  {
+    code: 101,
+    name: "Switching Protocols",
+    category: "Informational",
+    description: "The server is switching to a different protocol requested by the client.",
+  },
+  {
+    code: 102,
+    name: "Processing",
+    category: "Informational",
+    description: "The server received the request and is still working on it.",
+  },
+  {
+    code: 103,
+    name: "Early Hints",
+    category: "Informational",
+    description: "The server is sending preload hints before the final response.",
+  },
+  { code: 200, name: "OK", category: "Success", description: "The request succeeded." },
+  {
+    code: 201,
+    name: "Created",
+    category: "Success",
+    description: "The request succeeded and created a new resource.",
+  },
+  {
+    code: 202,
+    name: "Accepted",
+    category: "Success",
+    description: "The request was accepted for asynchronous processing.",
+  },
+  {
+    code: 203,
+    name: "Non-Authoritative Information",
+    category: "Success",
+    description: "The response payload was transformed by a proxy.",
+  },
+  {
+    code: 204,
+    name: "No Content",
+    category: "Success",
+    description: "The request succeeded and there is no response body.",
+  },
+  {
+    code: 205,
+    name: "Reset Content",
+    category: "Success",
+    description: "The request succeeded and the client should reset the document view.",
+  },
+  {
+    code: 206,
+    name: "Partial Content",
+    category: "Success",
+    description: "The response contains the requested byte range.",
+  },
+  {
+    code: 207,
+    name: "Multi-Status",
+    category: "Success",
+    description: "The response contains multiple status codes for independent operations.",
+  },
+  {
+    code: 208,
+    name: "Already Reported",
+    category: "Success",
+    description: "Members of a DAV binding were already reported earlier in the response.",
+  },
+  {
+    code: 226,
+    name: "IM Used",
+    category: "Success",
+    description: "The server fulfilled the GET request using an instance-manipulation result.",
+  },
+  {
+    code: 300,
+    name: "Multiple Choices",
+    category: "Redirection",
+    description: "The request has more than one possible response.",
+  },
+  {
+    code: 301,
+    name: "Moved Permanently",
+    category: "Redirection",
+    description: "The resource now lives at a new permanent URL.",
+  },
+  {
+    code: 302,
+    name: "Found",
+    category: "Redirection",
+    description: "The resource temporarily lives at a different URL.",
+  },
+  {
+    code: 303,
+    name: "See Other",
+    category: "Redirection",
+    description: "The response can be found at another URI with a GET request.",
+  },
+  {
+    code: 304,
+    name: "Not Modified",
+    category: "Redirection",
+    description: "The cached representation is still valid.",
+  },
+  {
+    code: 305,
+    name: "Use Proxy",
+    category: "Redirection",
+    description: "The requested resource must be accessed through the listed proxy.",
+  },
+  {
+    code: 307,
+    name: "Temporary Redirect",
+    category: "Redirection",
+    description: "Repeat the request at another URI without changing the method.",
+  },
+  {
+    code: 308,
+    name: "Permanent Redirect",
+    category: "Redirection",
+    description: "Repeat the request at another URI and preserve the method.",
+  },
+  {
+    code: 400,
+    name: "Bad Request",
+    category: "Client Error",
+    description: "The server could not understand the request.",
+  },
+  {
+    code: 401,
+    name: "Unauthorized",
+    category: "Client Error",
+    description: "Authentication is required to access the resource.",
+  },
+  {
+    code: 402,
+    name: "Payment Required",
+    category: "Client Error",
+    description: "Reserved for future use or digital payment workflows.",
+  },
+  {
+    code: 403,
+    name: "Forbidden",
+    category: "Client Error",
+    description: "The server understood the request but refuses to authorize it.",
+  },
+  {
+    code: 404,
+    name: "Not Found",
+    category: "Client Error",
+    description: "The requested resource could not be found.",
+  },
+  {
+    code: 405,
+    name: "Method Not Allowed",
+    category: "Client Error",
+    description: "The request method is not allowed for this resource.",
+  },
+  {
+    code: 406,
+    name: "Not Acceptable",
+    category: "Client Error",
+    description: "No available representation matches the request headers.",
+  },
+  {
+    code: 407,
+    name: "Proxy Authentication Required",
+    category: "Client Error",
+    description: "Authentication is required with the proxy.",
+  },
+  {
+    code: 408,
+    name: "Request Timeout",
+    category: "Client Error",
+    description: "The server timed out while waiting for the request.",
+  },
+  {
+    code: 409,
+    name: "Conflict",
+    category: "Client Error",
+    description: "The request conflicts with the current resource state.",
+  },
+  {
+    code: 410,
+    name: "Gone",
+    category: "Client Error",
+    description: "The resource is gone and will not be available again.",
+  },
+  {
+    code: 411,
+    name: "Length Required",
+    category: "Client Error",
+    description: "A Content-Length header is required.",
+  },
+  {
+    code: 412,
+    name: "Precondition Failed",
+    category: "Client Error",
+    description: "One of the request preconditions evaluated to false.",
+  },
+  {
+    code: 413,
+    name: "Content Too Large",
+    category: "Client Error",
+    description: "The request entity is larger than the server is willing to process.",
+  },
+  {
+    code: 414,
+    name: "URI Too Long",
+    category: "Client Error",
+    description: "The target URI is longer than the server is willing to interpret.",
+  },
+  {
+    code: 415,
+    name: "Unsupported Media Type",
+    category: "Client Error",
+    description: "The request payload format is not supported.",
+  },
+  {
+    code: 416,
+    name: "Range Not Satisfiable",
+    category: "Client Error",
+    description: "The requested range cannot be served.",
+  },
+  {
+    code: 417,
+    name: "Expectation Failed",
+    category: "Client Error",
+    description: "The Expect request-header field could not be met.",
+  },
+  {
+    code: 418,
+    name: "I'm a Teapot",
+    category: "Client Error",
+    description: "The server refuses to brew coffee because it is a teapot.",
+  },
+  {
+    code: 421,
+    name: "Misdirected Request",
+    category: "Client Error",
+    description: "The request was directed at a server that cannot produce a response.",
+  },
+  {
+    code: 422,
+    name: "Unprocessable Content",
+    category: "Client Error",
+    description: "The request syntax is valid but semantically invalid.",
+  },
+  {
+    code: 423,
+    name: "Locked",
+    category: "Client Error",
+    description: "The target resource is locked.",
+  },
+  {
+    code: 424,
+    name: "Failed Dependency",
+    category: "Client Error",
+    description: "The request failed because a dependent request failed.",
+  },
+  {
+    code: 425,
+    name: "Too Early",
+    category: "Client Error",
+    description: "The server is unwilling to risk processing a replayable request.",
+  },
+  {
+    code: 426,
+    name: "Upgrade Required",
+    category: "Client Error",
+    description: "The server requires the client to switch protocols.",
+  },
+  {
+    code: 428,
+    name: "Precondition Required",
+    category: "Client Error",
+    description: "The origin server requires the request to be conditional.",
+  },
+  {
+    code: 429,
+    name: "Too Many Requests",
+    category: "Client Error",
+    description: "The user has sent too many requests in a given amount of time.",
+  },
+  {
+    code: 431,
+    name: "Request Header Fields Too Large",
+    category: "Client Error",
+    description: "The request headers are too large to process.",
+  },
+  {
+    code: 451,
+    name: "Unavailable For Legal Reasons",
+    category: "Client Error",
+    description: "The resource is unavailable due to legal demands.",
+  },
+  {
+    code: 500,
+    name: "Internal Server Error",
+    category: "Server Error",
+    description: "The server encountered an unexpected condition.",
+  },
+  {
+    code: 501,
+    name: "Not Implemented",
+    category: "Server Error",
+    description: "The server does not support the requested functionality.",
+  },
+  {
+    code: 502,
+    name: "Bad Gateway",
+    category: "Server Error",
+    description: "The server received an invalid response from an upstream server.",
+  },
+  {
+    code: 503,
+    name: "Service Unavailable",
+    category: "Server Error",
+    description: "The server is temporarily unavailable.",
+  },
+  {
+    code: 504,
+    name: "Gateway Timeout",
+    category: "Server Error",
+    description: "An upstream server failed to send a timely response.",
+  },
+  {
+    code: 505,
+    name: "HTTP Version Not Supported",
+    category: "Server Error",
+    description: "The server does not support the HTTP protocol version used.",
+  },
+  {
+    code: 506,
+    name: "Variant Also Negotiates",
+    category: "Server Error",
+    description: "Transparent content negotiation for the request results in a circular reference.",
+  },
+  {
+    code: 507,
+    name: "Insufficient Storage",
+    category: "Server Error",
+    description: "The server cannot store the representation needed to complete the request.",
+  },
+  {
+    code: 508,
+    name: "Loop Detected",
+    category: "Server Error",
+    description: "The server detected an infinite loop while processing the request.",
+  },
+  {
+    code: 510,
+    name: "Not Extended",
+    category: "Server Error",
+    description: "Further extensions to the request are required for fulfillment.",
+  },
+  {
+    code: 511,
+    name: "Network Authentication Required",
+    category: "Server Error",
+    description: "The client needs to authenticate to gain network access.",
+  },
+];
+
+export function searchHttpStatusCodes(query: string): HttpStatusCodeEntry[] {
+  const normalizedQuery = query.trim().toLocaleLowerCase();
+
+  if (normalizedQuery.length === 0) {
+    return HTTP_STATUS_CODES;
+  }
+
+  return HTTP_STATUS_CODES.filter((entry) => {
+    const haystack = [String(entry.code), entry.name, entry.category, entry.description]
+      .join(" ")
+      .toLocaleLowerCase();
+
+    return haystack.includes(normalizedQuery);
+  });
+}

--- a/src/tools/http-status-codes/HttpStatusCodesTool.tsx
+++ b/src/tools/http-status-codes/HttpStatusCodesTool.tsx
@@ -1,0 +1,95 @@
+import { createMemo, createSignal, For } from "solid-js";
+
+import CopyButton from "@/components/CopyButton";
+import ToolStatusMessage from "@/components/ToolStatusMessage";
+import { searchHttpStatusCodes } from "@/lib/httpStatusCodes";
+
+export default function HttpStatusCodesTool() {
+  const [query, setQuery] = createSignal("");
+  const results = createMemo(() => searchHttpStatusCodes(query()));
+
+  const labelStyle = {
+    "font-size": "0.75rem",
+    "font-weight": "600" as const,
+    "letter-spacing": "0.05em",
+    "text-transform": "uppercase" as const,
+    color: "var(--text-secondary)",
+  };
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        "flex-direction": "column",
+        gap: "1rem",
+        padding: "1.5rem",
+        "max-width": "960px",
+        margin: "0 auto",
+        width: "100%",
+      }}
+    >
+      <div style={{ display: "flex", "flex-direction": "column", gap: "0.375rem" }}>
+        <label style={labelStyle}>Search by code or name</label>
+        <input
+          type="search"
+          value={query()}
+          onInput={(event) => setQuery(event.currentTarget.value)}
+          placeholder="Try 404, unprocessable, or redirect…"
+          spellcheck={false}
+          style={{
+            width: "100%",
+            padding: "0.875rem 1rem",
+            "border-radius": "0.5rem",
+            border: "1px solid var(--border)",
+            background: "var(--bg-secondary)",
+            color: "var(--text-primary)",
+            "font-size": "0.9375rem",
+            outline: "none",
+            "box-sizing": "border-box",
+          }}
+        />
+      </div>
+
+      <ToolStatusMessage tone="muted">
+        {results().length.toLocaleString()} status code{results().length === 1 ? "" : "s"} shown
+        from a bundled local reference.
+      </ToolStatusMessage>
+
+      <div style={{ display: "flex", "flex-direction": "column", gap: "0.75rem" }}>
+        <For each={results()}>
+          {(entry) => (
+            <section
+              style={{
+                display: "flex",
+                "flex-direction": "column",
+                gap: "0.5rem",
+                padding: "1rem",
+                background: "var(--bg-secondary)",
+                border: "1px solid var(--border)",
+                "border-radius": "0.75rem",
+              }}
+            >
+              <div style={{ display: "flex", "justify-content": "space-between", gap: "1rem" }}>
+                <div style={{ display: "flex", "flex-direction": "column", gap: "0.25rem" }}>
+                  <div style={{ display: "flex", gap: "0.625rem", "align-items": "baseline" }}>
+                    <strong style={{ color: "var(--text-primary)", "font-size": "1.375rem" }}>
+                      {entry.code}
+                    </strong>
+                    <span style={{ color: "var(--text-primary)", "font-size": "1rem" }}>
+                      {entry.name}
+                    </span>
+                  </div>
+                  <span style={labelStyle}>{entry.category}</span>
+                </div>
+                <CopyButton text={`${entry.code} ${entry.name}`} label="Copy entry" />
+              </div>
+              <p style={{ margin: 0, color: "var(--text-secondary)", "line-height": 1.6 }}>
+                {entry.description}
+              </p>
+            </section>
+          )}
+        </For>
+      </div>
+    </div>
+  );
+}

--- a/src/tools/registry.test.ts
+++ b/src/tools/registry.test.ts
@@ -48,4 +48,12 @@ describe("tool registry", () => {
       componentPath: "/src/tools/url-encoder/UrlEncoderTool.tsx",
     });
   });
+
+  it("includes the HTTP status codes route", () => {
+    expect(getToolBySlug("http-status-codes")).toMatchObject({
+      id: "http-status-codes",
+      category: "network",
+      componentPath: "/src/tools/http-status-codes/HttpStatusCodesTool.tsx",
+    });
+  });
 });

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -140,6 +140,16 @@ export const tools: Tool[] = [
     slug: "url-encoder",
     componentPath: "/src/tools/url-encoder/UrlEncoderTool.tsx",
   },
+  {
+    id: "http-status-codes",
+    name: "HTTP Status Codes",
+    description: "Search a bundled local reference of common HTTP response codes.",
+    category: "network",
+    keywords: ["http", "status", "codes", "response", "network", "api"],
+    icon: "BadgeInfo",
+    slug: "http-status-codes",
+    componentPath: "/src/tools/http-status-codes/HttpStatusCodesTool.tsx",
+  },
 ];
 
 export function getToolRoute(slug: string): `/tools/${string}` {


### PR DESCRIPTION
## Summary
Add a bundled local HTTP status-code reference with pure dataset and search helpers in `src/lib/*`, then keep the UI thin around those helpers. The tool stays fully offline, supports searching by code or name, and registers the new route through the shared registry.

## Issue coverage
- #130 — fully addressed: adds the HTTP status-code reference, pure helper coverage, and route registration.

## Changes
- add a bundled HTTP status-code dataset plus local search helpers across codes, names, categories, and descriptions
- add an `http-status-codes` tool with a searchable list of copyable entries
- extend registry coverage with a route smoke assertion for the new tool

## Testing
- [x] `bun run test src/lib/httpStatusCodes.test.ts src/tools/registry.test.ts`
- [x] `bun run verify`
- [ ] manually verify searches like `404`, `unprocessable`, and `redirect` in the browser

## References
- Closes #130
