### PR TITLE
feat(data): add a JSON to YAML converter

### DIFF
--- a/src/lib/jsonToYaml.test.ts
+++ b/src/lib/jsonToYaml.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { convertJsonToYaml } from "./jsonToYaml";
+
+describe("convertJsonToYaml", () => {
+  it("converts nested JSON values into stable YAML output", () => {
+    const result = convertJsonToYaml(
+      '{"z":true,"a":{"c":2,"b":1},"items":[{"name":"alpha"},null]}'
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      output: ["a:", "  b: 1", "  c: 2", "items:", "  - name: alpha", "  - null", "z: true"].join(
+        "\n"
+      ),
+    });
+  });
+
+  it("surfaces clear validation feedback for invalid JSON", () => {
+    expect(convertJsonToYaml('{"missing": }')).toEqual({
+      ok: false,
+      error: expect.stringContaining("JSON"),
+    });
+  });
+});

--- a/src/lib/jsonToYaml.ts
+++ b/src/lib/jsonToYaml.ts
@@ -1,0 +1,40 @@
+import { stringify } from "yaml";
+
+import { sortJsonKeys } from "./jsonFormatter";
+
+export type JsonToYamlResult =
+  | {
+      ok: true;
+      output: string;
+    }
+  | {
+      ok: false;
+      error: string;
+    };
+
+export function convertJsonToYaml(input: string): JsonToYamlResult {
+  if (input.trim().length === 0) {
+    return {
+      ok: true,
+      output: "",
+    };
+  }
+
+  try {
+    const parsed = JSON.parse(input) as unknown;
+    const sorted = sortJsonKeys(parsed);
+
+    return {
+      ok: true,
+      output: stringify(sorted, {
+        defaultStringType: "PLAIN",
+        sortMapEntries: true,
+      }).trimEnd(),
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      error: `Invalid JSON input: ${error instanceof Error ? error.message : "Unable to parse JSON."}`,
+    };
+  }
+}

--- a/src/tools/json-to-yaml/JsonToYamlTool.tsx
+++ b/src/tools/json-to-yaml/JsonToYamlTool.tsx
@@ -1,0 +1,108 @@
+import { createMemo, createSignal, Show } from "solid-js";
+
+import CopyButton from "@/components/CopyButton";
+import ToolStatusMessage from "@/components/ToolStatusMessage";
+import { convertJsonToYaml } from "@/lib/jsonToYaml";
+
+export default function JsonToYamlTool() {
+  const [input, setInput] = createSignal('{\n  "hello": "world"\n}');
+  const result = createMemo(() => convertJsonToYaml(input()));
+  const output = createMemo(() => {
+    const current = result();
+    return current.ok ? current.output : "";
+  });
+  const error = createMemo(() => {
+    const current = result();
+    return current.ok ? "" : current.error;
+  });
+
+  const labelStyle = {
+    "font-size": "0.75rem",
+    "font-weight": "600" as const,
+    "letter-spacing": "0.05em",
+    "text-transform": "uppercase" as const,
+    color: "var(--text-secondary)",
+  };
+
+  return (
+    <div
+      style={{
+        display: "grid",
+        gap: "1.25rem",
+        padding: "1.5rem",
+        "max-width": "1100px",
+        margin: "0 auto",
+        width: "100%",
+        "grid-template-columns": "repeat(auto-fit, minmax(320px, 1fr))",
+      }}
+    >
+      <section style={{ display: "flex", "flex-direction": "column", gap: "0.375rem" }}>
+        <label style={labelStyle}>JSON input</label>
+        <textarea
+          value={input()}
+          onInput={(event) => setInput(event.currentTarget.value)}
+          placeholder="Paste JSON to convert…"
+          rows={14}
+          spellcheck={false}
+          style={{
+            width: "100%",
+            padding: "0.875rem 1rem",
+            "border-radius": "0.5rem",
+            border: `1px solid ${error() ? "var(--accent-error)" : "var(--border)"}`,
+            background: "var(--bg-secondary)",
+            color: "var(--text-primary)",
+            "font-family": "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+            "font-size": "0.875rem",
+            "line-height": "1.6",
+            resize: "vertical",
+            outline: "none",
+            "box-sizing": "border-box",
+          }}
+        />
+      </section>
+
+      <section
+        style={{
+          display: "flex",
+          "flex-direction": "column",
+          gap: "0.75rem",
+          padding: "1rem",
+          background: "var(--bg-secondary)",
+          border: "1px solid var(--border)",
+          "border-radius": "0.75rem",
+        }}
+      >
+        <div
+          style={{ display: "flex", "align-items": "center", "justify-content": "space-between" }}
+        >
+          <span style={labelStyle}>YAML output</span>
+          <CopyButton text={output()} label="Copy YAML" />
+        </div>
+
+        <Show
+          when={!error()}
+          fallback={<ToolStatusMessage tone="error">{error()}</ToolStatusMessage>}
+        >
+          <pre
+            style={{
+              margin: "0",
+              padding: "1rem",
+              "border-radius": "0.5rem",
+              border: "1px solid var(--border)",
+              background: "var(--bg-primary)",
+              color: "var(--text-primary)",
+              "font-family": "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+              "font-size": "0.875rem",
+              "line-height": "1.7",
+              "white-space": "pre-wrap",
+              "word-break": "break-word",
+              "min-height": "20rem",
+            }}
+          >
+            {output() || "—"}
+          </pre>
+        </Show>
+      </section>
+    </div>
+  );
+}

--- a/src/tools/registry.test.ts
+++ b/src/tools/registry.test.ts
@@ -56,4 +56,12 @@ describe("tool registry", () => {
       componentPath: "/src/tools/http-status-codes/HttpStatusCodesTool.tsx",
     });
   });
+
+  it("includes the JSON to YAML route", () => {
+    expect(getToolBySlug("json-to-yaml")).toMatchObject({
+      id: "json-to-yaml",
+      category: "data",
+      componentPath: "/src/tools/json-to-yaml/JsonToYamlTool.tsx",
+    });
+  });
 });

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -150,6 +150,16 @@ export const tools: Tool[] = [
     slug: "http-status-codes",
     componentPath: "/src/tools/http-status-codes/HttpStatusCodesTool.tsx",
   },
+  {
+    id: "json-to-yaml",
+    name: "JSON to YAML",
+    description: "Convert JSON documents into YAML locally with stable nested key ordering.",
+    category: "data",
+    keywords: ["json", "yaml", "convert", "data", "serialize", "format"],
+    icon: "ArrowRightLeft",
+    slug: "json-to-yaml",
+    componentPath: "/src/tools/json-to-yaml/JsonToYamlTool.tsx",
+  },
 ];
 
 export function getToolRoute(slug: string): `/tools/${string}` {


### PR DESCRIPTION
## Summary
Add a local-only JSON to YAML converter with pure conversion helpers in `src/lib/*` and a thin UI around them. The implementation validates JSON input, emits stable YAML for nested structures, and registers the new route through the shared registry.

## Issue coverage
- #124 — fully addressed: adds the JSON to YAML converter, pure helper coverage, and route registration.

## Changes
- add `convertJsonToYaml(...)` with stable nested key ordering and clear invalid-JSON feedback
- add a `json-to-yaml` tool with copyable YAML output
- extend registry coverage with a route smoke assertion for the new tool

## Testing
- [x] `bun run test src/lib/jsonToYaml.test.ts src/tools/registry.test.ts`
- [x] `bun run verify`
- [ ] manually verify nested objects, arrays, booleans, nulls, and invalid JSON in the browser

## References
- Closes #124
