### PR TITLE
feat(data): add a YAML to JSON converter

### DIFF
--- a/src/lib/yamlToJson.test.ts
+++ b/src/lib/yamlToJson.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { convertYamlToJson } from "./yamlToJson";
+
+describe("convertYamlToJson", () => {
+  it("converts representative YAML into formatted JSON", () => {
+    expect(
+      convertYamlToJson(["name: demo", "enabled: true", "items:", "  - 1", "  - null"].join("\n"))
+    ).toEqual({
+      ok: true,
+      output: JSON.stringify({ enabled: true, items: [1, null], name: "demo" }, null, 2),
+    });
+  });
+
+  it("surfaces clear validation feedback for invalid YAML", () => {
+    expect(convertYamlToJson("name: [")).toEqual({
+      ok: false,
+      error: expect.stringContaining("YAML"),
+    });
+  });
+});

--- a/src/lib/yamlToJson.ts
+++ b/src/lib/yamlToJson.ts
@@ -1,0 +1,43 @@
+import { parseDocument } from "yaml";
+
+import { sortJsonKeys } from "./jsonFormatter";
+
+export type YamlToJsonResult =
+  | {
+      ok: true;
+      output: string;
+    }
+  | {
+      ok: false;
+      error: string;
+    };
+
+export function convertYamlToJson(input: string): YamlToJsonResult {
+  if (input.trim().length === 0) {
+    return {
+      ok: true,
+      output: "",
+    };
+  }
+
+  try {
+    const document = parseDocument(input);
+
+    if (document.errors.length > 0) {
+      throw document.errors[0];
+    }
+
+    const parsed = document.toJS() as unknown;
+    const sorted = sortJsonKeys(parsed);
+
+    return {
+      ok: true,
+      output: JSON.stringify(sorted, null, 2),
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      error: `Invalid YAML input: ${error instanceof Error ? error.message : "Unable to parse YAML."}`,
+    };
+  }
+}

--- a/src/tools/registry.test.ts
+++ b/src/tools/registry.test.ts
@@ -64,4 +64,12 @@ describe("tool registry", () => {
       componentPath: "/src/tools/json-to-yaml/JsonToYamlTool.tsx",
     });
   });
+
+  it("includes the YAML to JSON route", () => {
+    expect(getToolBySlug("yaml-to-json")).toMatchObject({
+      id: "yaml-to-json",
+      category: "data",
+      componentPath: "/src/tools/yaml-to-json/YamlToJsonTool.tsx",
+    });
+  });
 });

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -160,6 +160,16 @@ export const tools: Tool[] = [
     slug: "json-to-yaml",
     componentPath: "/src/tools/json-to-yaml/JsonToYamlTool.tsx",
   },
+  {
+    id: "yaml-to-json",
+    name: "YAML to JSON",
+    description: "Convert YAML documents into formatted JSON locally.",
+    category: "data",
+    keywords: ["yaml", "json", "convert", "data", "parse", "format"],
+    icon: "ArrowRightLeft",
+    slug: "yaml-to-json",
+    componentPath: "/src/tools/yaml-to-json/YamlToJsonTool.tsx",
+  },
 ];
 
 export function getToolRoute(slug: string): `/tools/${string}` {

--- a/src/tools/yaml-to-json/YamlToJsonTool.tsx
+++ b/src/tools/yaml-to-json/YamlToJsonTool.tsx
@@ -1,0 +1,108 @@
+import { createMemo, createSignal, Show } from "solid-js";
+
+import CopyButton from "@/components/CopyButton";
+import ToolStatusMessage from "@/components/ToolStatusMessage";
+import { convertYamlToJson } from "@/lib/yamlToJson";
+
+export default function YamlToJsonTool() {
+  const [input, setInput] = createSignal("name: demo\nenabled: true");
+  const result = createMemo(() => convertYamlToJson(input()));
+  const output = createMemo(() => {
+    const current = result();
+    return current.ok ? current.output : "";
+  });
+  const error = createMemo(() => {
+    const current = result();
+    return current.ok ? "" : current.error;
+  });
+
+  const labelStyle = {
+    "font-size": "0.75rem",
+    "font-weight": "600" as const,
+    "letter-spacing": "0.05em",
+    "text-transform": "uppercase" as const,
+    color: "var(--text-secondary)",
+  };
+
+  return (
+    <div
+      style={{
+        display: "grid",
+        gap: "1.25rem",
+        padding: "1.5rem",
+        "max-width": "1100px",
+        margin: "0 auto",
+        width: "100%",
+        "grid-template-columns": "repeat(auto-fit, minmax(320px, 1fr))",
+      }}
+    >
+      <section style={{ display: "flex", "flex-direction": "column", gap: "0.375rem" }}>
+        <label style={labelStyle}>YAML input</label>
+        <textarea
+          value={input()}
+          onInput={(event) => setInput(event.currentTarget.value)}
+          placeholder="Paste YAML to convert…"
+          rows={14}
+          spellcheck={false}
+          style={{
+            width: "100%",
+            padding: "0.875rem 1rem",
+            "border-radius": "0.5rem",
+            border: `1px solid ${error() ? "var(--accent-error)" : "var(--border)"}`,
+            background: "var(--bg-secondary)",
+            color: "var(--text-primary)",
+            "font-family": "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+            "font-size": "0.875rem",
+            "line-height": "1.6",
+            resize: "vertical",
+            outline: "none",
+            "box-sizing": "border-box",
+          }}
+        />
+      </section>
+
+      <section
+        style={{
+          display: "flex",
+          "flex-direction": "column",
+          gap: "0.75rem",
+          padding: "1rem",
+          background: "var(--bg-secondary)",
+          border: "1px solid var(--border)",
+          "border-radius": "0.75rem",
+        }}
+      >
+        <div
+          style={{ display: "flex", "align-items": "center", "justify-content": "space-between" }}
+        >
+          <span style={labelStyle}>JSON output</span>
+          <CopyButton text={output()} label="Copy JSON" />
+        </div>
+
+        <Show
+          when={!error()}
+          fallback={<ToolStatusMessage tone="error">{error()}</ToolStatusMessage>}
+        >
+          <pre
+            style={{
+              margin: "0",
+              padding: "1rem",
+              "border-radius": "0.5rem",
+              border: "1px solid var(--border)",
+              background: "var(--bg-primary)",
+              color: "var(--text-primary)",
+              "font-family": "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+              "font-size": "0.875rem",
+              "line-height": "1.7",
+              "white-space": "pre-wrap",
+              "word-break": "break-word",
+              "min-height": "20rem",
+            }}
+          >
+            {output() || "—"}
+          </pre>
+        </Show>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Add a local-only YAML to JSON converter with pure conversion helpers in `src/lib/*` and a thin UI around them. The implementation validates YAML input, emits formatted JSON for nested structures, and registers the new route through the shared registry.

## Issue coverage
- #125 — fully addressed: adds the YAML to JSON converter, pure helper coverage, and route registration.

## Changes
- add `convertYamlToJson(...)` with stable nested key ordering and clear invalid-YAML feedback
- add a `yaml-to-json` tool with copyable JSON output
- extend registry coverage with a route smoke assertion for the new tool

## Testing
- [x] `bun run test src/lib/yamlToJson.test.ts src/tools/registry.test.ts`
- [x] `bun run verify`
- [ ] manually verify representative YAML documents and malformed input in the browser

## References
- Closes #125
