### PR TITLE
feat(data): add a YAML formatter

### DIFF
--- a/src/lib/yamlFormatter.test.ts
+++ b/src/lib/yamlFormatter.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { formatYaml } from "./yamlFormatter";
+
+describe("formatYaml", () => {
+  it("formats valid YAML with the requested indentation", () => {
+    expect(formatYaml("root:\n  child:\n    - 1\n    - 2", { indent: 4, sortKeys: false })).toEqual(
+      {
+        ok: true,
+        output: ["root:", "    child:", "        - 1", "        - 2"].join("\n"),
+      }
+    );
+  });
+
+  it("sorts keys recursively when requested", () => {
+    expect(formatYaml("z: true\na:\n  c: 2\n  b: 1", { indent: 2, sortKeys: true })).toEqual({
+      ok: true,
+      output: ["a:", "  b: 1", "  c: 2", "z: true"].join("\n"),
+    });
+  });
+
+  it("returns clear feedback for invalid YAML", () => {
+    expect(formatYaml("root: [", { indent: 2, sortKeys: false })).toEqual({
+      ok: false,
+      error: expect.stringContaining("YAML"),
+    });
+  });
+});

--- a/src/lib/yamlFormatter.ts
+++ b/src/lib/yamlFormatter.ts
@@ -1,0 +1,52 @@
+import { parseDocument, stringify } from "yaml";
+
+import { sortJsonKeys } from "./jsonFormatter";
+
+export interface YamlFormatterOptions {
+  indent: number;
+  sortKeys: boolean;
+}
+
+export type YamlFormatterResult =
+  | {
+      ok: true;
+      output: string;
+    }
+  | {
+      ok: false;
+      error: string;
+    };
+
+export function formatYaml(input: string, options: YamlFormatterOptions): YamlFormatterResult {
+  if (input.trim().length === 0) {
+    return {
+      ok: true,
+      output: "",
+    };
+  }
+
+  try {
+    const document = parseDocument(input);
+
+    if (document.errors.length > 0) {
+      throw document.errors[0];
+    }
+
+    const parsed = document.toJS() as unknown;
+    const value = options.sortKeys ? sortJsonKeys(parsed) : parsed;
+
+    return {
+      ok: true,
+      output: stringify(value, {
+        indent: Math.min(8, Math.max(2, Math.trunc(options.indent) || 2)),
+        defaultStringType: "PLAIN",
+        sortMapEntries: options.sortKeys,
+      }).trimEnd(),
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      error: `Invalid YAML input: ${error instanceof Error ? error.message : "Unable to format YAML."}`,
+    };
+  }
+}

--- a/src/tools/registry.test.ts
+++ b/src/tools/registry.test.ts
@@ -72,4 +72,12 @@ describe("tool registry", () => {
       componentPath: "/src/tools/yaml-to-json/YamlToJsonTool.tsx",
     });
   });
+
+  it("includes the YAML formatter route", () => {
+    expect(getToolBySlug("yaml-formatter")).toMatchObject({
+      id: "yaml-formatter",
+      category: "data",
+      componentPath: "/src/tools/yaml-formatter/YamlFormatterTool.tsx",
+    });
+  });
 });

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -170,6 +170,16 @@ export const tools: Tool[] = [
     slug: "yaml-to-json",
     componentPath: "/src/tools/yaml-to-json/YamlToJsonTool.tsx",
   },
+  {
+    id: "yaml-formatter",
+    name: "YAML Formatter",
+    description: "Format YAML locally with indent controls and optional key sorting.",
+    category: "data",
+    keywords: ["yaml", "format", "prettify", "indent", "sort", "lint"],
+    icon: "AlignLeft",
+    slug: "yaml-formatter",
+    componentPath: "/src/tools/yaml-formatter/YamlFormatterTool.tsx",
+  },
 ];
 
 export function getToolRoute(slug: string): `/tools/${string}` {

--- a/src/tools/yaml-formatter/YamlFormatterTool.tsx
+++ b/src/tools/yaml-formatter/YamlFormatterTool.tsx
@@ -1,0 +1,135 @@
+import { createMemo, createSignal, Show } from "solid-js";
+
+import CopyButton from "@/components/CopyButton";
+import ToolActionButton from "@/components/ToolActionButton";
+import ToolStatusMessage from "@/components/ToolStatusMessage";
+import { formatYaml } from "@/lib/yamlFormatter";
+
+export default function YamlFormatterTool() {
+  const [input, setInput] = createSignal("root:\n  child: [3, 2, 1]");
+  const [indent, setIndent] = createSignal(2);
+  const [sortKeys, setSortKeys] = createSignal(false);
+
+  const result = createMemo(() => formatYaml(input(), { indent: indent(), sortKeys: sortKeys() }));
+  const output = createMemo(() => {
+    const current = result();
+    return current.ok ? current.output : "";
+  });
+  const error = createMemo(() => {
+    const current = result();
+    return current.ok ? "" : current.error;
+  });
+
+  const labelStyle = {
+    "font-size": "0.75rem",
+    "font-weight": "600" as const,
+    "letter-spacing": "0.05em",
+    "text-transform": "uppercase" as const,
+    color: "var(--text-secondary)",
+  };
+
+  return (
+    <div
+      style={{
+        display: "grid",
+        gap: "1.25rem",
+        padding: "1.5rem",
+        "max-width": "1100px",
+        margin: "0 auto",
+        width: "100%",
+        "grid-template-columns": "repeat(auto-fit, minmax(320px, 1fr))",
+      }}
+    >
+      <section style={{ display: "flex", "flex-direction": "column", gap: "0.75rem" }}>
+        <div
+          style={{ display: "flex", "align-items": "center", gap: "0.75rem", "flex-wrap": "wrap" }}
+        >
+          <label style={labelStyle}>Indent</label>
+          <input
+            type="number"
+            min={2}
+            max={8}
+            value={indent()}
+            onInput={(event) => setIndent(Number(event.currentTarget.value) || 2)}
+            style={{
+              width: "5rem",
+              padding: "0.5rem 0.75rem",
+              "border-radius": "0.5rem",
+              border: "1px solid var(--border)",
+              background: "var(--bg-secondary)",
+              color: "var(--text-primary)",
+            }}
+          />
+          <ToolActionButton active={sortKeys()} onClick={() => setSortKeys((current) => !current)}>
+            Sort keys
+          </ToolActionButton>
+        </div>
+
+        <textarea
+          value={input()}
+          onInput={(event) => setInput(event.currentTarget.value)}
+          placeholder="Paste YAML to format…"
+          rows={14}
+          spellcheck={false}
+          style={{
+            width: "100%",
+            padding: "0.875rem 1rem",
+            "border-radius": "0.5rem",
+            border: `1px solid ${error() ? "var(--accent-error)" : "var(--border)"}`,
+            background: "var(--bg-secondary)",
+            color: "var(--text-primary)",
+            "font-family": "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+            "font-size": "0.875rem",
+            "line-height": "1.6",
+            resize: "vertical",
+            outline: "none",
+            "box-sizing": "border-box",
+          }}
+        />
+      </section>
+
+      <section
+        style={{
+          display: "flex",
+          "flex-direction": "column",
+          gap: "0.75rem",
+          padding: "1rem",
+          background: "var(--bg-secondary)",
+          border: "1px solid var(--border)",
+          "border-radius": "0.75rem",
+        }}
+      >
+        <div
+          style={{ display: "flex", "align-items": "center", "justify-content": "space-between" }}
+        >
+          <span style={labelStyle}>Formatted YAML</span>
+          <CopyButton text={output()} label="Copy YAML" />
+        </div>
+
+        <Show
+          when={!error()}
+          fallback={<ToolStatusMessage tone="error">{error()}</ToolStatusMessage>}
+        >
+          <pre
+            style={{
+              margin: "0",
+              padding: "1rem",
+              "border-radius": "0.5rem",
+              border: "1px solid var(--border)",
+              background: "var(--bg-primary)",
+              color: "var(--text-primary)",
+              "font-family": "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+              "font-size": "0.875rem",
+              "line-height": "1.7",
+              "white-space": "pre-wrap",
+              "word-break": "break-word",
+              "min-height": "20rem",
+            }}
+          >
+            {output() || "—"}
+          </pre>
+        </Show>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Add a local-only YAML formatter with pure formatting helpers in `src/lib/*` and a thin UI around them. The implementation validates YAML input, supports configurable indentation and optional key sorting, and registers the new route through the shared registry.

## Issue coverage
- #126 — fully addressed: adds the YAML formatter, pure helper coverage, and route registration.

## Changes
- add `formatYaml(...)` with indentation control, optional recursive key sorting, and clear invalid-YAML feedback
- add a `yaml-formatter` tool with copyable formatted output
- extend registry coverage with a route smoke assertion for the new tool

## Testing
- [x] `bun run test src/lib/yamlFormatter.test.ts src/tools/registry.test.ts`
- [x] `bun run verify`
- [ ] manually verify nested YAML, lists, anchors/aliases as supported, and invalid input in the browser

## References
- Closes #126
