### PR TITLE
feat(data): add an XML formatter

### DIFF
--- a/src/lib/xmlFormatter.test.ts
+++ b/src/lib/xmlFormatter.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { formatXml } from "./xmlFormatter";
+
+describe("formatXml", () => {
+  it("formats compact XML with predictable indentation", () => {
+    expect(formatXml('<root><item id="1">value</item><empty /></root>', { indent: 2 })).toEqual({
+      ok: true,
+      output: [
+        "<root>",
+        '  <item id="1">',
+        "    value",
+        "  </item>",
+        "  <empty />",
+        "</root>",
+      ].join("\n"),
+    });
+  });
+
+  it("normalizes already formatted XML to the requested indentation", () => {
+    expect(
+      formatXml("<root>\n<child>\n<name>demo</name>\n</child>\n</root>", { indent: 4 })
+    ).toEqual({
+      ok: true,
+      output: [
+        "<root>",
+        "    <child>",
+        "        <name>",
+        "            demo",
+        "        </name>",
+        "    </child>",
+        "</root>",
+      ].join("\n"),
+    });
+  });
+
+  it("returns clear feedback for malformed XML", () => {
+    expect(formatXml("<root><child></root>", { indent: 2 })).toEqual({
+      ok: false,
+      error: expect.stringContaining("XML"),
+    });
+  });
+});

--- a/src/lib/xmlFormatter.ts
+++ b/src/lib/xmlFormatter.ts
@@ -1,0 +1,161 @@
+export interface XmlFormatterOptions {
+  indent: number;
+}
+
+export type XmlFormatterResult =
+  | {
+      ok: true;
+      output: string;
+    }
+  | {
+      ok: false;
+      error: string;
+    };
+
+type XmlToken =
+  | { type: "open"; raw: string; name: string }
+  | { type: "close"; raw: string; name: string }
+  | { type: "self" | "declaration" | "comment" | "cdata"; raw: string }
+  | { type: "text"; raw: string };
+
+function tokenizeXml(input: string): XmlToken[] {
+  const tokens: XmlToken[] = [];
+  let index = 0;
+
+  while (index < input.length) {
+    if (input[index] !== "<") {
+      const nextTagIndex = input.indexOf("<", index);
+      const end = nextTagIndex === -1 ? input.length : nextTagIndex;
+      tokens.push({ type: "text", raw: input.slice(index, end) });
+      index = end;
+      continue;
+    }
+
+    if (input.startsWith("<!--", index)) {
+      const end = input.indexOf("-->", index + 4);
+      if (end === -1) {
+        throw new Error("Unterminated XML comment");
+      }
+      tokens.push({ type: "comment", raw: input.slice(index, end + 3) });
+      index = end + 3;
+      continue;
+    }
+
+    if (input.startsWith("<![CDATA[", index)) {
+      const end = input.indexOf("]]>", index + 9);
+      if (end === -1) {
+        throw new Error("Unterminated CDATA section");
+      }
+      tokens.push({ type: "cdata", raw: input.slice(index, end + 3) });
+      index = end + 3;
+      continue;
+    }
+
+    const end = input.indexOf(">", index + 1);
+    if (end === -1) {
+      throw new Error("Unterminated XML tag");
+    }
+
+    const raw = input.slice(index, end + 1);
+    index = end + 1;
+
+    if (raw.startsWith("<?") || raw.startsWith("<!DOCTYPE")) {
+      tokens.push({ type: "declaration", raw });
+      continue;
+    }
+
+    const closeMatch = raw.match(/^<\/(.+?)>$/s);
+    if (closeMatch) {
+      tokens.push({ type: "close", raw, name: closeMatch[1].trim() });
+      continue;
+    }
+
+    const openMatch = raw.match(/^<([^!?][^\s/>]*)(?:\s[^>]*)?>$/s);
+    const selfMatch = raw.match(/^<([^!?][^\s/>]*)(?:\s[^>]*)?\/>$/s);
+
+    if (selfMatch) {
+      tokens.push({ type: "self", raw });
+      continue;
+    }
+
+    if (openMatch) {
+      tokens.push({ type: "open", raw, name: openMatch[1].trim() });
+      continue;
+    }
+
+    throw new Error(`Unsupported XML token: ${raw}`);
+  }
+
+  return tokens;
+}
+
+function validateTokens(tokens: XmlToken[]): void {
+  const stack: string[] = [];
+
+  for (const token of tokens) {
+    if (token.type === "open") {
+      stack.push(token.name);
+      continue;
+    }
+
+    if (token.type === "close") {
+      const expected = stack.pop();
+      if (expected !== token.name) {
+        throw new Error(
+          `Mismatched closing tag: expected </${expected ?? "?"}> but found </${token.name}>`
+        );
+      }
+    }
+  }
+
+  if (stack.length > 0) {
+    throw new Error(`Unclosed XML tag: <${stack.at(-1)}>`);
+  }
+}
+
+export function formatXml(input: string, options: XmlFormatterOptions): XmlFormatterResult {
+  if (input.trim().length === 0) {
+    return { ok: true, output: "" };
+  }
+
+  try {
+    const tokens = tokenizeXml(input);
+    validateTokens(tokens);
+
+    const lines: string[] = [];
+    const indentUnit = " ".repeat(Math.min(8, Math.max(2, Math.trunc(options.indent) || 2)));
+    let level = 0;
+
+    for (const token of tokens) {
+      if (token.type === "text") {
+        const value = token.raw.trim();
+        if (value.length > 0) {
+          lines.push(`${indentUnit.repeat(level)}${value}`);
+        }
+        continue;
+      }
+
+      if (token.type === "close") {
+        level = Math.max(0, level - 1);
+        lines.push(`${indentUnit.repeat(level)}${token.raw}`);
+        continue;
+      }
+
+      lines.push(`${indentUnit.repeat(level)}${token.raw}`);
+
+      if (token.type === "open") {
+        level += 1;
+      }
+    }
+
+    return {
+      ok: true,
+      output: lines.join("\n"),
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      error: `Invalid XML input: ${error instanceof Error ? error.message : "Unable to format XML."}`,
+    };
+  }
+}

--- a/src/tools/registry.test.ts
+++ b/src/tools/registry.test.ts
@@ -80,4 +80,12 @@ describe("tool registry", () => {
       componentPath: "/src/tools/yaml-formatter/YamlFormatterTool.tsx",
     });
   });
+
+  it("includes the XML formatter route", () => {
+    expect(getToolBySlug("xml-formatter")).toMatchObject({
+      id: "xml-formatter",
+      category: "data",
+      componentPath: "/src/tools/xml-formatter/XmlFormatterTool.tsx",
+    });
+  });
 });

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -180,6 +180,16 @@ export const tools: Tool[] = [
     slug: "yaml-formatter",
     componentPath: "/src/tools/yaml-formatter/YamlFormatterTool.tsx",
   },
+  {
+    id: "xml-formatter",
+    name: "XML Formatter",
+    description: "Format XML locally with indentation control and clear invalid-input feedback.",
+    category: "data",
+    keywords: ["xml", "format", "prettify", "indent", "markup", "validate"],
+    icon: "Brackets",
+    slug: "xml-formatter",
+    componentPath: "/src/tools/xml-formatter/XmlFormatterTool.tsx",
+  },
 ];
 
 export function getToolRoute(slug: string): `/tools/${string}` {

--- a/src/tools/xml-formatter/XmlFormatterTool.tsx
+++ b/src/tools/xml-formatter/XmlFormatterTool.tsx
@@ -1,0 +1,129 @@
+import { createMemo, createSignal, Show } from "solid-js";
+
+import CopyButton from "@/components/CopyButton";
+import ToolStatusMessage from "@/components/ToolStatusMessage";
+import { formatXml } from "@/lib/xmlFormatter";
+
+export default function XmlFormatterTool() {
+  const [input, setInput] = createSignal('<root><item id="1">value</item></root>');
+  const [indent, setIndent] = createSignal(2);
+  const result = createMemo(() => formatXml(input(), { indent: indent() }));
+  const output = createMemo(() => {
+    const current = result();
+    return current.ok ? current.output : "";
+  });
+  const error = createMemo(() => {
+    const current = result();
+    return current.ok ? "" : current.error;
+  });
+
+  const labelStyle = {
+    "font-size": "0.75rem",
+    "font-weight": "600" as const,
+    "letter-spacing": "0.05em",
+    "text-transform": "uppercase" as const,
+    color: "var(--text-secondary)",
+  };
+
+  return (
+    <div
+      style={{
+        display: "grid",
+        gap: "1.25rem",
+        padding: "1.5rem",
+        "max-width": "1100px",
+        margin: "0 auto",
+        width: "100%",
+        "grid-template-columns": "repeat(auto-fit, minmax(320px, 1fr))",
+      }}
+    >
+      <section style={{ display: "flex", "flex-direction": "column", gap: "0.75rem" }}>
+        <div
+          style={{ display: "flex", "align-items": "center", gap: "0.75rem", "flex-wrap": "wrap" }}
+        >
+          <label style={labelStyle}>Indent</label>
+          <input
+            type="number"
+            min={2}
+            max={8}
+            value={indent()}
+            onInput={(event) => setIndent(Number(event.currentTarget.value) || 2)}
+            style={{
+              width: "5rem",
+              padding: "0.5rem 0.75rem",
+              "border-radius": "0.5rem",
+              border: "1px solid var(--border)",
+              background: "var(--bg-secondary)",
+              color: "var(--text-primary)",
+            }}
+          />
+        </div>
+
+        <textarea
+          value={input()}
+          onInput={(event) => setInput(event.currentTarget.value)}
+          placeholder="Paste XML to format…"
+          rows={14}
+          spellcheck={false}
+          style={{
+            width: "100%",
+            padding: "0.875rem 1rem",
+            "border-radius": "0.5rem",
+            border: `1px solid ${error() ? "var(--accent-error)" : "var(--border)"}`,
+            background: "var(--bg-secondary)",
+            color: "var(--text-primary)",
+            "font-family": "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+            "font-size": "0.875rem",
+            "line-height": "1.6",
+            resize: "vertical",
+            outline: "none",
+            "box-sizing": "border-box",
+          }}
+        />
+      </section>
+
+      <section
+        style={{
+          display: "flex",
+          "flex-direction": "column",
+          gap: "0.75rem",
+          padding: "1rem",
+          background: "var(--bg-secondary)",
+          border: "1px solid var(--border)",
+          "border-radius": "0.75rem",
+        }}
+      >
+        <div
+          style={{ display: "flex", "align-items": "center", "justify-content": "space-between" }}
+        >
+          <span style={labelStyle}>Formatted XML</span>
+          <CopyButton text={output()} label="Copy XML" />
+        </div>
+
+        <Show
+          when={!error()}
+          fallback={<ToolStatusMessage tone="error">{error()}</ToolStatusMessage>}
+        >
+          <pre
+            style={{
+              margin: "0",
+              padding: "1rem",
+              "border-radius": "0.5rem",
+              border: "1px solid var(--border)",
+              background: "var(--bg-primary)",
+              color: "var(--text-primary)",
+              "font-family": "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+              "font-size": "0.875rem",
+              "line-height": "1.7",
+              "white-space": "pre-wrap",
+              "word-break": "break-word",
+              "min-height": "20rem",
+            }}
+          >
+            {output() || "—"}
+          </pre>
+        </Show>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Add a local-only XML formatter with pure formatting helpers in `src/lib/*` and a thin UI around them. The implementation validates XML structure, supports indentation control, and registers the new route through the shared registry.

## Issue coverage
- #127 — fully addressed: adds the XML formatter, pure helper coverage, and route registration.

## Changes
- add `formatXml(...)` with structural validation, indentation control, and clear invalid-XML feedback
- add an `xml-formatter` tool with copyable formatted output
- extend registry coverage with a route smoke assertion for the new tool

## Testing
- [x] `bun run test src/lib/xmlFormatter.test.ts src/tools/registry.test.ts`
- [x] `bun run verify`
- [ ] manually verify compact XML, already-formatted XML, and malformed XML in the browser

## References
- Closes #127
