### PR TITLE
feat(data): add a JSON to CSV converter

### DIFF
--- a/src/lib/jsonToCsv.test.ts
+++ b/src/lib/jsonToCsv.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { convertJsonToCsv } from "./jsonToCsv";
+
+describe("convertJsonToCsv", () => {
+  it("converts arrays of JSON objects with stable headers and escaped values", () => {
+    expect(
+      convertJsonToCsv(
+        JSON.stringify([
+          { name: "Alice", note: 'hello, "world"', active: true },
+          { name: "Bob", note: "line 1\nline 2" },
+        ])
+      )
+    ).toEqual({
+      ok: true,
+      output: ["name,note,active", 'Alice,"hello, ""world""",true', 'Bob,"line 1\nline 2",'].join(
+        "\n"
+      ),
+    });
+  });
+
+  it("rejects unsupported JSON shapes clearly", () => {
+    expect(convertJsonToCsv('{"name":"Alice"}')).toEqual({
+      ok: false,
+      error: "Input must be a JSON array of objects.",
+    });
+  });
+});

--- a/src/lib/jsonToCsv.ts
+++ b/src/lib/jsonToCsv.ts
@@ -1,0 +1,77 @@
+import { sortJsonKeys } from "./jsonFormatter";
+
+type JsonPrimitive = string | number | boolean | null;
+type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue };
+type JsonRecord = Record<string, JsonValue>;
+
+export type JsonToCsvResult =
+  | {
+      ok: true;
+      output: string;
+    }
+  | {
+      ok: false;
+      error: string;
+    };
+
+function isJsonRecord(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function escapeCsvCell(value: string): string {
+  return /[",\n\r]/.test(value) ? `"${value.replaceAll('"', '""')}"` : value;
+}
+
+function serializeCsvValue(value: JsonValue | undefined): string {
+  if (value === undefined || value === null) {
+    return "";
+  }
+
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+
+  return JSON.stringify(sortJsonKeys(value));
+}
+
+export function convertJsonToCsv(input: string): JsonToCsvResult {
+  try {
+    const parsed = JSON.parse(input) as unknown;
+
+    if (!Array.isArray(parsed) || !parsed.every(isJsonRecord)) {
+      return {
+        ok: false,
+        error: "Input must be a JSON array of objects.",
+      };
+    }
+
+    const headers: string[] = [];
+    for (const row of parsed) {
+      for (const key of Object.keys(row)) {
+        if (!headers.includes(key)) {
+          headers.push(key);
+        }
+      }
+    }
+
+    const lines = [headers.map(escapeCsvCell).join(",")];
+
+    for (const row of parsed) {
+      lines.push(headers.map((header) => escapeCsvCell(serializeCsvValue(row[header]))).join(","));
+    }
+
+    return {
+      ok: true,
+      output: lines.join("\n"),
+    };
+  } catch {
+    return {
+      ok: false,
+      error: "Invalid JSON input.",
+    };
+  }
+}

--- a/src/tools/json-to-csv/JsonToCsvTool.tsx
+++ b/src/tools/json-to-csv/JsonToCsvTool.tsx
@@ -1,0 +1,108 @@
+import { createMemo, createSignal, Show } from "solid-js";
+
+import CopyButton from "@/components/CopyButton";
+import ToolStatusMessage from "@/components/ToolStatusMessage";
+import { convertJsonToCsv } from "@/lib/jsonToCsv";
+
+export default function JsonToCsvTool() {
+  const [input, setInput] = createSignal('[{"name":"Alice","active":true},{"name":"Bob"}]');
+  const result = createMemo(() => convertJsonToCsv(input()));
+  const output = createMemo(() => {
+    const current = result();
+    return current.ok ? current.output : "";
+  });
+  const error = createMemo(() => {
+    const current = result();
+    return current.ok ? "" : current.error;
+  });
+
+  const labelStyle = {
+    "font-size": "0.75rem",
+    "font-weight": "600" as const,
+    "letter-spacing": "0.05em",
+    "text-transform": "uppercase" as const,
+    color: "var(--text-secondary)",
+  };
+
+  return (
+    <div
+      style={{
+        display: "grid",
+        gap: "1.25rem",
+        padding: "1.5rem",
+        "max-width": "1100px",
+        margin: "0 auto",
+        width: "100%",
+        "grid-template-columns": "repeat(auto-fit, minmax(320px, 1fr))",
+      }}
+    >
+      <section style={{ display: "flex", "flex-direction": "column", gap: "0.375rem" }}>
+        <label style={labelStyle}>JSON array input</label>
+        <textarea
+          value={input()}
+          onInput={(event) => setInput(event.currentTarget.value)}
+          placeholder="Paste an array of JSON objects to convert…"
+          rows={14}
+          spellcheck={false}
+          style={{
+            width: "100%",
+            padding: "0.875rem 1rem",
+            "border-radius": "0.5rem",
+            border: `1px solid ${error() ? "var(--accent-error)" : "var(--border)"}`,
+            background: "var(--bg-secondary)",
+            color: "var(--text-primary)",
+            "font-family": "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+            "font-size": "0.875rem",
+            "line-height": "1.6",
+            resize: "vertical",
+            outline: "none",
+            "box-sizing": "border-box",
+          }}
+        />
+      </section>
+
+      <section
+        style={{
+          display: "flex",
+          "flex-direction": "column",
+          gap: "0.75rem",
+          padding: "1rem",
+          background: "var(--bg-secondary)",
+          border: "1px solid var(--border)",
+          "border-radius": "0.75rem",
+        }}
+      >
+        <div
+          style={{ display: "flex", "align-items": "center", "justify-content": "space-between" }}
+        >
+          <span style={labelStyle}>CSV output</span>
+          <CopyButton text={output()} label="Copy CSV" />
+        </div>
+
+        <Show
+          when={!error()}
+          fallback={<ToolStatusMessage tone="error">{error()}</ToolStatusMessage>}
+        >
+          <pre
+            style={{
+              margin: "0",
+              padding: "1rem",
+              "border-radius": "0.5rem",
+              border: "1px solid var(--border)",
+              background: "var(--bg-primary)",
+              color: "var(--text-primary)",
+              "font-family": "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+              "font-size": "0.875rem",
+              "line-height": "1.7",
+              "white-space": "pre-wrap",
+              "word-break": "break-word",
+              "min-height": "20rem",
+            }}
+          >
+            {output() || "—"}
+          </pre>
+        </Show>
+      </section>
+    </div>
+  );
+}

--- a/src/tools/registry.test.ts
+++ b/src/tools/registry.test.ts
@@ -88,4 +88,12 @@ describe("tool registry", () => {
       componentPath: "/src/tools/xml-formatter/XmlFormatterTool.tsx",
     });
   });
+
+  it("includes the JSON to CSV route", () => {
+    expect(getToolBySlug("json-to-csv")).toMatchObject({
+      id: "json-to-csv",
+      category: "data",
+      componentPath: "/src/tools/json-to-csv/JsonToCsvTool.tsx",
+    });
+  });
 });

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -190,6 +190,16 @@ export const tools: Tool[] = [
     slug: "xml-formatter",
     componentPath: "/src/tools/xml-formatter/XmlFormatterTool.tsx",
   },
+  {
+    id: "json-to-csv",
+    name: "JSON to CSV",
+    description: "Convert arrays of JSON objects into CSV locally.",
+    category: "data",
+    keywords: ["json", "csv", "convert", "export", "table", "data"],
+    icon: "TableProperties",
+    slug: "json-to-csv",
+    componentPath: "/src/tools/json-to-csv/JsonToCsvTool.tsx",
+  },
 ];
 
 export function getToolRoute(slug: string): `/tools/${string}` {


### PR DESCRIPTION
## Summary
Add a local-only JSON to CSV converter with pure conversion helpers in `src/lib/*` and a thin UI around them. The implementation validates supported input shape, preserves stable headers, escapes CSV values correctly, and registers the new route through the shared registry.

## Issue coverage
- #128 — fully addressed: adds the JSON to CSV converter, pure helper coverage, and route registration.

## Changes
- add `convertJsonToCsv(...)` with stable column ordering, CSV escaping, and unsupported-shape validation
- add a `json-to-csv` tool with copyable CSV output
- extend registry coverage with a route smoke assertion for the new tool

## Testing
- [x] `bun run test src/lib/jsonToCsv.test.ts src/tools/registry.test.ts`
- [x] `bun run verify`
- [ ] manually verify representative JSON arrays, missing keys, and quoting behavior in the browser

## References
- Closes #128
