### PR TITLE
feat(security): add a chmod permission calculator

### DIFF
--- a/src/lib/chmod.test.ts
+++ b/src/lib/chmod.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { buildChmodResult } from "./chmod";
+
+describe("buildChmodResult", () => {
+  it("derives representative permission combinations", () => {
+    expect(
+      buildChmodResult({
+        owner: { read: true, write: true, execute: false },
+        group: { read: true, write: false, execute: false },
+        other: { read: true, write: false, execute: false },
+      })
+    ).toEqual({
+      octal: "644",
+      symbolic: "rw-r--r--",
+      command: "chmod 644 <path>",
+    });
+
+    expect(
+      buildChmodResult({
+        owner: { read: true, write: true, execute: true },
+        group: { read: true, write: false, execute: true },
+        other: { read: true, write: false, execute: true },
+      })
+    ).toEqual({
+      octal: "755",
+      symbolic: "rwxr-xr-x",
+      command: "chmod 755 <path>",
+    });
+  });
+
+  it("handles locked-down and fully-open permission sets", () => {
+    expect(
+      buildChmodResult({
+        owner: { read: true, write: true, execute: false },
+        group: { read: false, write: false, execute: false },
+        other: { read: false, write: false, execute: false },
+      })
+    ).toMatchObject({ octal: "600", symbolic: "rw-------" });
+
+    expect(
+      buildChmodResult({
+        owner: { read: true, write: true, execute: true },
+        group: { read: true, write: true, execute: true },
+        other: { read: true, write: true, execute: true },
+      })
+    ).toMatchObject({ octal: "777", symbolic: "rwxrwxrwx" });
+  });
+});

--- a/src/lib/chmod.ts
+++ b/src/lib/chmod.ts
@@ -1,0 +1,42 @@
+export interface PermissionBits {
+  read: boolean;
+  write: boolean;
+  execute: boolean;
+}
+
+export interface ChmodPermissions {
+  owner: PermissionBits;
+  group: PermissionBits;
+  other: PermissionBits;
+}
+
+export interface ChmodResult {
+  octal: string;
+  symbolic: string;
+  command: string;
+}
+
+function permissionToDigit(permission: PermissionBits): string {
+  const digit =
+    (permission.read ? 4 : 0) + (permission.write ? 2 : 0) + (permission.execute ? 1 : 0);
+  return String(digit);
+}
+
+function permissionToSymbolic(permission: PermissionBits): string {
+  return `${permission.read ? "r" : "-"}${permission.write ? "w" : "-"}${permission.execute ? "x" : "-"}`;
+}
+
+export function buildChmodResult(permissions: ChmodPermissions): ChmodResult {
+  const octal = [permissions.owner, permissions.group, permissions.other]
+    .map(permissionToDigit)
+    .join("");
+  const symbolic = [permissions.owner, permissions.group, permissions.other]
+    .map(permissionToSymbolic)
+    .join("");
+
+  return {
+    octal,
+    symbolic,
+    command: `chmod ${octal} <path>`,
+  };
+}

--- a/src/tools/chmod-calculator/ChmodCalculatorTool.tsx
+++ b/src/tools/chmod-calculator/ChmodCalculatorTool.tsx
@@ -1,0 +1,167 @@
+import { createMemo, createSignal, For } from "solid-js";
+
+import CopyButton from "@/components/CopyButton";
+import { buildChmodResult, type ChmodPermissions } from "@/lib/chmod";
+
+const SUBJECTS = [
+  ["owner", "Owner"],
+  ["group", "Group"],
+  ["other", "Other"],
+] as const satisfies ReadonlyArray<readonly [keyof ChmodPermissions, string]>;
+
+const PERMISSIONS = [
+  ["read", "Read"],
+  ["write", "Write"],
+  ["execute", "Execute"],
+] as const;
+
+const DEFAULT_PERMISSIONS: ChmodPermissions = {
+  owner: { read: true, write: true, execute: true },
+  group: { read: true, write: false, execute: true },
+  other: { read: true, write: false, execute: true },
+};
+
+export default function ChmodCalculatorTool() {
+  const [permissions, setPermissions] = createSignal<ChmodPermissions>(DEFAULT_PERMISSIONS);
+  const result = createMemo(() => buildChmodResult(permissions()));
+
+  const labelStyle = {
+    "font-size": "0.75rem",
+    "font-weight": "600" as const,
+    "letter-spacing": "0.05em",
+    "text-transform": "uppercase" as const,
+    color: "var(--text-secondary)",
+  };
+
+  function togglePermission(
+    subject: keyof ChmodPermissions,
+    permission: keyof ChmodPermissions["owner"]
+  ) {
+    setPermissions((current) => ({
+      ...current,
+      [subject]: {
+        ...current[subject],
+        [permission]: !current[subject][permission],
+      },
+    }));
+  }
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        "flex-direction": "column",
+        gap: "1.25rem",
+        padding: "1.5rem",
+        "max-width": "900px",
+        margin: "0 auto",
+        width: "100%",
+      }}
+    >
+      <section
+        style={{
+          overflow: "auto",
+          background: "var(--bg-secondary)",
+          border: "1px solid var(--border)",
+          "border-radius": "0.75rem",
+        }}
+      >
+        <table style={{ width: "100%", "border-collapse": "collapse" }}>
+          <thead>
+            <tr>
+              <th style={{ padding: "0.75rem 1rem", "text-align": "left", ...labelStyle }}>
+                Scope
+              </th>
+              <For each={PERMISSIONS}>
+                {([_, label]) => (
+                  <th style={{ padding: "0.75rem 1rem", "text-align": "left", ...labelStyle }}>
+                    {label}
+                  </th>
+                )}
+              </For>
+            </tr>
+          </thead>
+          <tbody>
+            <For each={SUBJECTS}>
+              {([subject, label]) => (
+                <tr>
+                  <td style={{ padding: "0.75rem 1rem", color: "var(--text-primary)" }}>{label}</td>
+                  <For each={PERMISSIONS}>
+                    {([permission]) => (
+                      <td style={{ padding: "0.75rem 1rem" }}>
+                        <input
+                          type="checkbox"
+                          checked={permissions()[subject][permission]}
+                          onChange={() => togglePermission(subject, permission)}
+                        />
+                      </td>
+                    )}
+                  </For>
+                </tr>
+              )}
+            </For>
+          </tbody>
+        </table>
+      </section>
+
+      <div
+        style={{
+          display: "grid",
+          gap: "0.75rem",
+          "grid-template-columns": "repeat(auto-fit, minmax(220px, 1fr))",
+        }}
+      >
+        <section
+          style={{
+            padding: "1rem",
+            background: "var(--bg-secondary)",
+            border: "1px solid var(--border)",
+            "border-radius": "0.75rem",
+          }}
+        >
+          <div style={{ display: "flex", "justify-content": "space-between", gap: "0.75rem" }}>
+            <span style={labelStyle}>Octal mode</span>
+            <CopyButton text={result().octal} label="Copy octal" />
+          </div>
+          <strong style={{ color: "var(--text-primary)", "font-size": "1.5rem" }}>
+            {result().octal}
+          </strong>
+        </section>
+
+        <section
+          style={{
+            padding: "1rem",
+            background: "var(--bg-secondary)",
+            border: "1px solid var(--border)",
+            "border-radius": "0.75rem",
+          }}
+        >
+          <div style={{ display: "flex", "justify-content": "space-between", gap: "0.75rem" }}>
+            <span style={labelStyle}>Symbolic mode</span>
+            <CopyButton text={result().symbolic} label="Copy symbolic" />
+          </div>
+          <strong style={{ color: "var(--text-primary)", "font-size": "1.5rem" }}>
+            {result().symbolic}
+          </strong>
+        </section>
+
+        <section
+          style={{
+            padding: "1rem",
+            background: "var(--bg-secondary)",
+            border: "1px solid var(--border)",
+            "border-radius": "0.75rem",
+          }}
+        >
+          <div style={{ display: "flex", "justify-content": "space-between", gap: "0.75rem" }}>
+            <span style={labelStyle}>Command</span>
+            <CopyButton text={result().command} label="Copy command" />
+          </div>
+          <code style={{ color: "var(--text-primary)", "font-size": "0.95rem" }}>
+            {result().command}
+          </code>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/tools/registry.test.ts
+++ b/src/tools/registry.test.ts
@@ -96,4 +96,12 @@ describe("tool registry", () => {
       componentPath: "/src/tools/json-to-csv/JsonToCsvTool.tsx",
     });
   });
+
+  it("includes the chmod calculator route", () => {
+    expect(getToolBySlug("chmod-calculator")).toMatchObject({
+      id: "chmod-calculator",
+      category: "security",
+      componentPath: "/src/tools/chmod-calculator/ChmodCalculatorTool.tsx",
+    });
+  });
 });

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -200,6 +200,16 @@ export const tools: Tool[] = [
     slug: "json-to-csv",
     componentPath: "/src/tools/json-to-csv/JsonToCsvTool.tsx",
   },
+  {
+    id: "chmod-calculator",
+    name: "chmod Calculator",
+    description: "Derive octal, symbolic, and command output for Unix file permissions.",
+    category: "security",
+    keywords: ["chmod", "permissions", "unix", "linux", "octal", "symbolic"],
+    icon: "ShieldCheck",
+    slug: "chmod-calculator",
+    componentPath: "/src/tools/chmod-calculator/ChmodCalculatorTool.tsx",
+  },
 ];
 
 export function getToolRoute(slug: string): `/tools/${string}` {


### PR DESCRIPTION
## Summary
Add a local-only chmod calculator with pure permission-derivation helpers in `src/lib/*` and a thin UI around them. The implementation keeps all permission math client-side, derives octal and symbolic modes immediately, and registers the new route through the shared registry.

## Issue coverage
- #129 — fully addressed: adds the chmod calculator, pure helper coverage, and route registration.

## Changes
- add `buildChmodResult(...)` to derive octal, symbolic, and shell command output from permission toggles
- add a `chmod-calculator` tool with copyable outputs for each derived representation
- extend registry coverage with a route smoke assertion for the new tool

## Testing
- [x] `bun run test src/lib/chmod.test.ts src/tools/registry.test.ts`
- [x] `bun run verify`
- [ ] manually verify common modes such as `644`, `755`, `600`, and `777` in the browser

## References
- Closes #129
