### PR TITLE
feat(security): add an HMAC generator

### DIFF
--- a/src/lib/hmac.test.ts
+++ b/src/lib/hmac.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { generateHmac, HMAC_ALGORITHMS } from "./hmac";
+
+describe("HMAC_ALGORITHMS", () => {
+  it("lists the supported SHA-based algorithms", () => {
+    expect(HMAC_ALGORITHMS.map((algorithm) => algorithm.id)).toEqual([
+      "SHA-1",
+      "SHA-256",
+      "SHA-384",
+      "SHA-512",
+    ]);
+  });
+});
+
+describe("generateHmac", () => {
+  it("formats a known SHA-256 test vector as lowercase hex", async () => {
+    await expect(
+      generateHmac({
+        message: "The quick brown fox jumps over the lazy dog",
+        secret: "key",
+        algorithm: "SHA-256",
+      })
+    ).resolves.toEqual({
+      ok: true,
+      output: "f7bc83f430538424b13298e6aa6fb143ef4d59a14946175997479dbc2d1a3cd8",
+    });
+  });
+
+  it("returns a clear error when Web Crypto is unavailable", async () => {
+    await expect(
+      generateHmac(
+        {
+          message: "hello",
+          secret: "world",
+          algorithm: "SHA-256",
+        },
+        null
+      )
+    ).resolves.toEqual({
+      ok: false,
+      error: "Web Crypto HMAC support is unavailable in this runtime.",
+    });
+  });
+});

--- a/src/lib/hmac.ts
+++ b/src/lib/hmac.ts
@@ -1,0 +1,62 @@
+export const HMAC_ALGORITHMS = [
+  { id: "SHA-1", label: "HMAC-SHA1" },
+  { id: "SHA-256", label: "HMAC-SHA256" },
+  { id: "SHA-384", label: "HMAC-SHA384" },
+  { id: "SHA-512", label: "HMAC-SHA512" },
+] as const;
+
+export type HmacAlgorithm = (typeof HMAC_ALGORITHMS)[number]["id"];
+
+export interface HmacInput {
+  message: string;
+  secret: string;
+  algorithm: HmacAlgorithm;
+}
+
+export type HmacResult =
+  | {
+      ok: true;
+      output: string;
+    }
+  | {
+      ok: false;
+      error: string;
+    };
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+export async function generateHmac(
+  input: HmacInput,
+  runtime: Pick<Crypto, "subtle"> | null = globalThis.crypto
+): Promise<HmacResult> {
+  if (!runtime?.subtle) {
+    return {
+      ok: false,
+      error: "Web Crypto HMAC support is unavailable in this runtime.",
+    };
+  }
+
+  try {
+    const encoder = new TextEncoder();
+    const key = await runtime.subtle.importKey(
+      "raw",
+      encoder.encode(input.secret),
+      { name: "HMAC", hash: input.algorithm },
+      false,
+      ["sign"]
+    );
+    const signature = await runtime.subtle.sign("HMAC", key, encoder.encode(input.message));
+
+    return {
+      ok: true,
+      output: bytesToHex(new Uint8Array(signature)),
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : "Unable to generate HMAC.",
+    };
+  }
+}

--- a/src/tools/hmac-generator/HmacGeneratorTool.tsx
+++ b/src/tools/hmac-generator/HmacGeneratorTool.tsx
@@ -1,0 +1,177 @@
+import { createSignal, For, Show } from "solid-js";
+
+import CopyButton from "@/components/CopyButton";
+import ToolActionButton from "@/components/ToolActionButton";
+import ToolStatusMessage from "@/components/ToolStatusMessage";
+import { generateHmac, HMAC_ALGORITHMS, type HmacAlgorithm } from "@/lib/hmac";
+
+export default function HmacGeneratorTool() {
+  const [message, setMessage] = createSignal("");
+  const [secret, setSecret] = createSignal("");
+  const [algorithm, setAlgorithm] = createSignal<HmacAlgorithm>("SHA-256");
+  const [output, setOutput] = createSignal("");
+  const [error, setError] = createSignal("");
+  const [pending, setPending] = createSignal(false);
+
+  const labelStyle = {
+    "font-size": "0.75rem",
+    "font-weight": "600" as const,
+    "letter-spacing": "0.05em",
+    "text-transform": "uppercase" as const,
+    color: "var(--text-secondary)",
+  };
+
+  async function handleGenerate() {
+    setPending(true);
+    const result = await generateHmac({
+      message: message(),
+      secret: secret(),
+      algorithm: algorithm(),
+    });
+    setPending(false);
+
+    if (result.ok) {
+      setOutput(result.output);
+      setError("");
+      return;
+    }
+
+    setOutput("");
+    setError(result.error);
+  }
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        "flex-direction": "column",
+        gap: "1.25rem",
+        padding: "1.5rem",
+        "max-width": "900px",
+        margin: "0 auto",
+        width: "100%",
+      }}
+    >
+      <div
+        style={{
+          display: "grid",
+          gap: "1rem",
+          "grid-template-columns": "repeat(auto-fit, minmax(260px, 1fr))",
+        }}
+      >
+        <div style={{ display: "flex", "flex-direction": "column", gap: "0.375rem" }}>
+          <label style={labelStyle}>Message</label>
+          <textarea
+            value={message()}
+            onInput={(event) => setMessage(event.currentTarget.value)}
+            rows={6}
+            spellcheck={false}
+            style={{
+              width: "100%",
+              padding: "0.875rem 1rem",
+              "border-radius": "0.5rem",
+              border: "1px solid var(--border)",
+              background: "var(--bg-secondary)",
+              color: "var(--text-primary)",
+              "font-family": "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+              "font-size": "0.875rem",
+              resize: "vertical",
+              outline: "none",
+              "box-sizing": "border-box",
+            }}
+          />
+        </div>
+
+        <div style={{ display: "flex", "flex-direction": "column", gap: "0.375rem" }}>
+          <label style={labelStyle}>Secret</label>
+          <textarea
+            value={secret()}
+            onInput={(event) => setSecret(event.currentTarget.value)}
+            rows={6}
+            spellcheck={false}
+            style={{
+              width: "100%",
+              padding: "0.875rem 1rem",
+              "border-radius": "0.5rem",
+              border: "1px solid var(--border)",
+              background: "var(--bg-secondary)",
+              color: "var(--text-primary)",
+              "font-family": "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+              "font-size": "0.875rem",
+              resize: "vertical",
+              outline: "none",
+              "box-sizing": "border-box",
+            }}
+          />
+        </div>
+      </div>
+
+      <div
+        style={{ display: "flex", gap: "0.75rem", "flex-wrap": "wrap", "align-items": "center" }}
+      >
+        <label style={labelStyle}>Algorithm</label>
+        <select
+          value={algorithm()}
+          onChange={(event) => setAlgorithm(event.currentTarget.value as HmacAlgorithm)}
+          style={{
+            padding: "0.5rem 0.75rem",
+            "border-radius": "0.5rem",
+            border: "1px solid var(--border)",
+            background: "var(--bg-secondary)",
+            color: "var(--text-primary)",
+          }}
+        >
+          <For each={HMAC_ALGORITHMS}>
+            {(item) => <option value={item.id}>{item.label}</option>}
+          </For>
+        </select>
+        <ToolActionButton
+          onClick={() => void handleGenerate()}
+          variant="primary"
+          disabled={pending()}
+        >
+          {pending() ? "Generating…" : "Generate HMAC"}
+        </ToolActionButton>
+      </div>
+
+      <Show when={error()}>
+        {(message) => <ToolStatusMessage tone="error">{message()}</ToolStatusMessage>}
+      </Show>
+
+      <section
+        style={{
+          display: "flex",
+          "flex-direction": "column",
+          gap: "0.75rem",
+          padding: "1rem",
+          background: "var(--bg-secondary)",
+          border: "1px solid var(--border)",
+          "border-radius": "0.75rem",
+        }}
+      >
+        <div
+          style={{ display: "flex", "align-items": "center", "justify-content": "space-between" }}
+        >
+          <span style={labelStyle}>Hex output</span>
+          <CopyButton text={output()} label="Copy HMAC" />
+        </div>
+        <code
+          style={{
+            color: "var(--text-primary)",
+            "font-size": "0.95rem",
+            "line-height": "1.7",
+            "font-family": "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+            "word-break": "break-all",
+            "min-height": "3rem",
+          }}
+        >
+          {output() || "—"}
+        </code>
+      </section>
+
+      <ToolStatusMessage tone="muted">
+        Secrets remain in memory only and are processed with the browser&apos;s Web Crypto API.
+      </ToolStatusMessage>
+    </div>
+  );
+}

--- a/src/tools/registry.test.ts
+++ b/src/tools/registry.test.ts
@@ -104,4 +104,12 @@ describe("tool registry", () => {
       componentPath: "/src/tools/chmod-calculator/ChmodCalculatorTool.tsx",
     });
   });
+
+  it("includes the HMAC generator route", () => {
+    expect(getToolBySlug("hmac-generator")).toMatchObject({
+      id: "hmac-generator",
+      category: "security",
+      componentPath: "/src/tools/hmac-generator/HmacGeneratorTool.tsx",
+    });
+  });
 });

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -210,6 +210,16 @@ export const tools: Tool[] = [
     slug: "chmod-calculator",
     componentPath: "/src/tools/chmod-calculator/ChmodCalculatorTool.tsx",
   },
+  {
+    id: "hmac-generator",
+    name: "HMAC Generator",
+    description: "Generate SHA-based HMAC signatures locally with the browser Web Crypto API.",
+    category: "security",
+    keywords: ["hmac", "crypto", "sha", "signature", "secret", "webhook"],
+    icon: "KeyRound",
+    slug: "hmac-generator",
+    componentPath: "/src/tools/hmac-generator/HmacGeneratorTool.tsx",
+  },
 ];
 
 export function getToolRoute(slug: string): `/tools/${string}` {


### PR DESCRIPTION
## Summary
Add a local-only HMAC generator with pure signing helpers in `src/lib/*` and a thin UI around them. The implementation uses the browser Web Crypto API, emits lowercase hex output, surfaces unsupported-runtime errors clearly, and registers the new route through the shared registry.

## Issue coverage
- #131 — fully addressed: adds the HMAC generator, pure helper coverage, and route registration.

## Changes
- add `generateHmac(...)` with SHA-based algorithm selection, lowercase hex output, and explicit runtime fallback errors
- add a `hmac-generator` tool with message input, secret input, algorithm selection, and copyable output
- extend registry coverage with a route smoke assertion for the new tool

## Testing
- [x] `bun run test src/lib/hmac.test.ts src/tools/registry.test.ts`
- [x] `bun run verify`
- [ ] manually verify a known SHA-256 test vector in the browser

## References
- Closes #131
