### PR TITLE
feat(url): add a local-only URL and query string inspector

### DIFF
--- a/src/lib/urlInspector.test.ts
+++ b/src/lib/urlInspector.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { inspectUrl } from "./urlInspector";
+
+describe("inspectUrl", () => {
+  it("parses full URLs and preserves duplicate query keys", () => {
+    expect(
+      inspectUrl("https://user:pass@example.com:8443/path/name?foo=1&foo=2&bar=hello%20world#frag")
+    ).toEqual({
+      ok: true,
+      inspection: {
+        kind: "url",
+        normalized:
+          "https://user:pass@example.com:8443/path/name?foo=1&foo=2&bar=hello%20world#frag",
+        protocol: "https:",
+        hostname: "example.com",
+        port: "8443",
+        path: "/path/name",
+        hash: "#frag",
+        username: "user",
+        password: "pass",
+        queryParams: [
+          { key: "foo", value: "1" },
+          { key: "foo", value: "2" },
+          { key: "bar", value: "hello world" },
+        ],
+      },
+    });
+  });
+
+  it("parses raw query strings locally", () => {
+    expect(inspectUrl("?a=1&a=2&space=hello%20world")).toEqual({
+      ok: true,
+      inspection: {
+        kind: "query",
+        normalized: "?a=1&a=2&space=hello+world",
+        protocol: "",
+        hostname: "",
+        port: "",
+        path: "",
+        hash: "",
+        username: "",
+        password: "",
+        queryParams: [
+          { key: "a", value: "1" },
+          { key: "a", value: "2" },
+          { key: "space", value: "hello world" },
+        ],
+      },
+    });
+  });
+
+  it("returns clear validation feedback for invalid input", () => {
+    expect(inspectUrl("not a url")).toEqual({
+      ok: false,
+      error: "Enter a full URL or a raw query string.",
+    });
+  });
+});

--- a/src/lib/urlInspector.ts
+++ b/src/lib/urlInspector.ts
@@ -1,0 +1,101 @@
+export interface UrlQueryParam {
+  key: string;
+  value: string;
+}
+
+export interface UrlInspection {
+  kind: "url" | "query";
+  normalized: string;
+  protocol: string;
+  hostname: string;
+  port: string;
+  path: string;
+  hash: string;
+  username: string;
+  password: string;
+  queryParams: UrlQueryParam[];
+}
+
+export type UrlInspectionResult =
+  | {
+      ok: true;
+      inspection: UrlInspection;
+    }
+  | {
+      ok: false;
+      error: string;
+    };
+
+function toQueryParams(params: URLSearchParams): UrlQueryParam[] {
+  return Array.from(params.entries(), ([key, value]) => ({ key, value }));
+}
+
+function looksLikeRawQueryString(input: string): boolean {
+  const trimmed = input.trim();
+  return (
+    trimmed.startsWith("?") ||
+    (!/\s/.test(trimmed) && (trimmed.includes("=") || trimmed.includes("&")))
+  );
+}
+
+function inspectQueryString(input: string): UrlInspectionResult {
+  const trimmed = input.trim();
+  const query = trimmed.startsWith("?") ? trimmed.slice(1) : trimmed;
+  const params = new URLSearchParams(query);
+
+  return {
+    ok: true,
+    inspection: {
+      kind: "query",
+      normalized: query.length > 0 ? `?${params.toString()}` : "",
+      protocol: "",
+      hostname: "",
+      port: "",
+      path: "",
+      hash: "",
+      username: "",
+      password: "",
+      queryParams: toQueryParams(params),
+    },
+  };
+}
+
+export function inspectUrl(input: string): UrlInspectionResult {
+  const trimmed = input.trim();
+
+  if (trimmed.length === 0) {
+    return {
+      ok: false,
+      error: "Enter a full URL or a raw query string.",
+    };
+  }
+
+  try {
+    const url = new URL(trimmed);
+
+    return {
+      ok: true,
+      inspection: {
+        kind: "url",
+        normalized: url.href,
+        protocol: url.protocol,
+        hostname: url.hostname,
+        port: url.port,
+        path: url.pathname,
+        hash: url.hash,
+        username: url.username,
+        password: url.password,
+        queryParams: toQueryParams(url.searchParams),
+      },
+    };
+  } catch {
+    if (looksLikeRawQueryString(trimmed)) {
+      return inspectQueryString(trimmed);
+    }
+
+    return {
+      ok: false,
+      error: "Enter a full URL or a raw query string.",
+    };
+  }
+}

--- a/src/tools/registry.test.ts
+++ b/src/tools/registry.test.ts
@@ -112,4 +112,12 @@ describe("tool registry", () => {
       componentPath: "/src/tools/hmac-generator/HmacGeneratorTool.tsx",
     });
   });
+
+  it("includes the URL inspector route", () => {
+    expect(getToolBySlug("url-inspector")).toMatchObject({
+      id: "url-inspector",
+      category: "network",
+      componentPath: "/src/tools/url-inspector/UrlInspectorTool.tsx",
+    });
+  });
 });

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -220,6 +220,16 @@ export const tools: Tool[] = [
     slug: "hmac-generator",
     componentPath: "/src/tools/hmac-generator/HmacGeneratorTool.tsx",
   },
+  {
+    id: "url-inspector",
+    name: "URL Inspector",
+    description: "Parse full URLs or raw query strings locally and inspect decoded sections.",
+    category: "network",
+    keywords: ["url", "query", "params", "parse", "inspect", "search"],
+    icon: "Globe",
+    slug: "url-inspector",
+    componentPath: "/src/tools/url-inspector/UrlInspectorTool.tsx",
+  },
 ];
 
 export function getToolRoute(slug: string): `/tools/${string}` {

--- a/src/tools/url-inspector/UrlInspectorTool.tsx
+++ b/src/tools/url-inspector/UrlInspectorTool.tsx
@@ -1,0 +1,192 @@
+import { createMemo, createSignal, For, Show } from "solid-js";
+
+import CopyButton from "@/components/CopyButton";
+import ToolStatusMessage from "@/components/ToolStatusMessage";
+import { inspectUrl } from "@/lib/urlInspector";
+
+const SECTION_LABELS = [
+  ["normalized", "Normalized"],
+  ["protocol", "Protocol"],
+  ["hostname", "Hostname"],
+  ["port", "Port"],
+  ["path", "Path"],
+  ["hash", "Hash"],
+  ["username", "Username"],
+  ["password", "Password"],
+] as const;
+
+export default function UrlInspectorTool() {
+  const [input, setInput] = createSignal(
+    "https://user:pass@example.com:8443/path/name?foo=1&foo=2&bar=hello%20world#frag"
+  );
+  const result = createMemo(() => inspectUrl(input()));
+
+  const inspection = createMemo(() => {
+    const current = result();
+    return current.ok ? current.inspection : null;
+  });
+  const error = createMemo(() => {
+    const current = result();
+    return current.ok ? "" : current.error;
+  });
+
+  const labelStyle = {
+    "font-size": "0.75rem",
+    "font-weight": "600" as const,
+    "letter-spacing": "0.05em",
+    "text-transform": "uppercase" as const,
+    color: "var(--text-secondary)",
+  };
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        "flex-direction": "column",
+        gap: "1.25rem",
+        padding: "1.5rem",
+        "max-width": "1100px",
+        margin: "0 auto",
+        width: "100%",
+      }}
+    >
+      <div style={{ display: "flex", "flex-direction": "column", gap: "0.375rem" }}>
+        <label style={labelStyle}>URL or raw query string</label>
+        <textarea
+          value={input()}
+          onInput={(event) => setInput(event.currentTarget.value)}
+          rows={5}
+          spellcheck={false}
+          style={{
+            width: "100%",
+            padding: "0.875rem 1rem",
+            "border-radius": "0.5rem",
+            border: `1px solid ${error() ? "var(--accent-error)" : "var(--border)"}`,
+            background: "var(--bg-secondary)",
+            color: "var(--text-primary)",
+            "font-family": "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+            "font-size": "0.875rem",
+            "line-height": "1.6",
+            resize: "vertical",
+            outline: "none",
+            "box-sizing": "border-box",
+          }}
+        />
+      </div>
+
+      <Show
+        when={!error()}
+        fallback={<ToolStatusMessage tone="error">{error()}</ToolStatusMessage>}
+      >
+        <div
+          style={{
+            display: "grid",
+            gap: "0.75rem",
+            "grid-template-columns": "repeat(auto-fit, minmax(220px, 1fr))",
+          }}
+        >
+          <For each={SECTION_LABELS}>
+            {([key, label]) => {
+              const value = () => {
+                const current = inspection();
+                if (!current) return "";
+                return key === "normalized" ? current.normalized : current[key];
+              };
+
+              return (
+                <section
+                  style={{
+                    display: "flex",
+                    "flex-direction": "column",
+                    gap: "0.5rem",
+                    padding: "0.875rem",
+                    background: "var(--bg-secondary)",
+                    border: "1px solid var(--border)",
+                    "border-radius": "0.5rem",
+                  }}
+                >
+                  <div
+                    style={{ display: "flex", "justify-content": "space-between", gap: "0.75rem" }}
+                  >
+                    <span style={labelStyle}>{label}</span>
+                    <CopyButton text={value()} label={`Copy ${label}`} />
+                  </div>
+                  <code
+                    style={{
+                      color: "var(--text-primary)",
+                      "font-size": "0.875rem",
+                      "line-height": "1.6",
+                      "word-break": "break-all",
+                    }}
+                  >
+                    {value() || "—"}
+                  </code>
+                </section>
+              );
+            }}
+          </For>
+        </div>
+
+        <section
+          style={{
+            display: "flex",
+            "flex-direction": "column",
+            gap: "0.75rem",
+            padding: "1rem",
+            background: "var(--bg-secondary)",
+            border: "1px solid var(--border)",
+            "border-radius": "0.75rem",
+          }}
+        >
+          <div style={{ display: "flex", "justify-content": "space-between", gap: "0.75rem" }}>
+            <span style={labelStyle}>Decoded query params</span>
+            <Show when={inspection()?.normalized}>
+              <ToolStatusMessage tone="muted" style={{ padding: "0.375rem 0.625rem" }}>
+                {inspection()?.kind === "query" ? "raw query" : "full url"}
+              </ToolStatusMessage>
+            </Show>
+          </div>
+
+          <div style={{ overflow: "auto" }}>
+            <table style={{ width: "100%", "border-collapse": "collapse" }}>
+              <thead>
+                <tr>
+                  <th style={{ padding: "0.5rem 0.75rem", "text-align": "left", ...labelStyle }}>
+                    #
+                  </th>
+                  <th style={{ padding: "0.5rem 0.75rem", "text-align": "left", ...labelStyle }}>
+                    Key
+                  </th>
+                  <th style={{ padding: "0.5rem 0.75rem", "text-align": "left", ...labelStyle }}>
+                    Value
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <For each={inspection()?.queryParams ?? []}>
+                  {(param, index) => (
+                    <tr>
+                      <td style={{ padding: "0.5rem 0.75rem", color: "var(--text-muted)" }}>
+                        {index() + 1}
+                      </td>
+                      <td style={{ padding: "0.5rem 0.75rem", color: "var(--text-primary)" }}>
+                        <code>{param.key || "—"}</code>
+                      </td>
+                      <td style={{ padding: "0.5rem 0.75rem", color: "var(--text-primary)" }}>
+                        <code>{param.value || "—"}</code>
+                      </td>
+                    </tr>
+                  )}
+                </For>
+              </tbody>
+            </table>
+          </div>
+
+          <Show when={(inspection()?.queryParams.length ?? 0) === 0}>
+            <ToolStatusMessage tone="muted">No query params found.</ToolStatusMessage>
+          </Show>
+        </section>
+      </Show>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Add a local-only URL inspector with pure parsing helpers in `src/lib/*` and a thin UI around them. The implementation parses full URLs or raw query strings entirely in-browser, preserves duplicate query keys, and registers the new route through the shared registry.

## Issue coverage
- #85 — fully addressed: adds the URL inspector, pure helper coverage, and route registration.

## Changes
- add `inspectUrl(...)` to parse full URLs or raw query strings, normalize output, and decode duplicate query params
- add a `url-inspector` tool with copyable normalized sections and a decoded query-params table
- extend registry coverage with a route smoke assertion for the new tool

## Testing
- [x] `bun run test src/lib/urlInspector.test.ts src/tools/registry.test.ts`
- [x] `bun run verify`
- [ ] manually verify full URLs, raw query strings, encoded values, and duplicate-key cases in the browser

## References
- Closes #85
