### PR TITLE
feat(cron): add humanized schedule output and next-run previews

### DIFF
--- a/src/lib/cronSchedule.test.ts
+++ b/src/lib/cronSchedule.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import { parseCronExpression } from "./cron";
+import { buildCronScheduleSummary, describeCronSchedule, getNextCronRuns } from "./cronSchedule";
+
+describe("describeCronSchedule", () => {
+  it("humanizes stepped schedules with explicit timezone wording", () => {
+    const parsed = parseCronExpression("*/15 * * * *");
+    expect(parsed.ok).toBe(true);
+
+    if (!parsed.ok) {
+      throw new Error("Expected a parsed cron expression.");
+    }
+
+    expect(describeCronSchedule(parsed.value, "utc")).toBe("Every 15 minutes using UTC");
+  });
+
+  it("humanizes weekday-specific schedules", () => {
+    const parsed = parseCronExpression("30 9 * * 1");
+    expect(parsed.ok).toBe(true);
+
+    if (!parsed.ok) {
+      throw new Error("Expected a parsed cron expression.");
+    }
+
+    expect(describeCronSchedule(parsed.value, "local")).toBe("At 09:30 on Monday using local time");
+  });
+});
+
+describe("getNextCronRuns", () => {
+  it("generates upcoming run previews locally from the parsed schedule", () => {
+    const parsed = parseCronExpression("30 9 * * 1");
+    expect(parsed.ok).toBe(true);
+
+    if (!parsed.ok) {
+      throw new Error("Expected a parsed cron expression.");
+    }
+
+    const runs = getNextCronRuns(parsed.value, {
+      start: new Date("2024-01-01T08:45:00Z"),
+      count: 2,
+      timeZone: "utc",
+    });
+
+    expect(runs.map((run) => run.toISOString())).toEqual([
+      "2024-01-01T09:30:00.000Z",
+      "2024-01-08T09:30:00.000Z",
+    ]);
+  });
+});
+
+describe("buildCronScheduleSummary", () => {
+  it("reuses parser errors for invalid expressions", () => {
+    expect(
+      buildCronScheduleSummary("* * *", {
+        start: new Date("2024-01-01T00:00:00Z"),
+        count: 3,
+        timeZone: "utc",
+      })
+    ).toEqual({
+      ok: false,
+      error: {
+        field: "expression",
+        message: "Cron expressions must contain exactly five fields.",
+      },
+    });
+  });
+});

--- a/src/lib/cronSchedule.ts
+++ b/src/lib/cronSchedule.ts
@@ -1,0 +1,250 @@
+import {
+  CRON_FIELD_SPECS,
+  type CronAtomicField,
+  type CronExpression,
+  type CronField,
+  type CronParseError,
+  parseCronExpression,
+} from "./cron";
+
+export type CronTimeZoneMode = "local" | "utc";
+
+export type CronScheduleSummary =
+  | {
+      ok: true;
+      description: string;
+      nextRuns: Date[];
+    }
+  | {
+      ok: false;
+      error: CronParseError;
+    };
+
+const WEEKDAY_NAMES = [
+  "Sunday",
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+] as const;
+
+function expandAtomicField(field: CronAtomicField, min: number, max: number): number[] {
+  if (field.kind === "wildcard") {
+    return Array.from({ length: max - min + 1 }, (_, index) => min + index);
+  }
+
+  if (field.kind === "value") {
+    return [field.value];
+  }
+
+  return Array.from({ length: field.end - field.start + 1 }, (_, index) => field.start + index);
+}
+
+function expandField(field: CronField, min: number, max: number): number[] {
+  if (field.kind === "list") {
+    return [...new Set(field.items.flatMap((item) => expandAtomicField(item, min, max)))].sort(
+      (left, right) => left - right
+    );
+  }
+
+  if (field.kind === "step") {
+    const baseValues = expandAtomicField(field.base, min, max);
+    const stepStart = field.base.kind === "wildcard" ? min : baseValues[0];
+
+    return baseValues.filter((value) => (value - stepStart) % field.step === 0);
+  }
+
+  return expandAtomicField(field, min, max);
+}
+
+function isWildcard(field: CronField): boolean {
+  return field.kind === "wildcard";
+}
+
+function formatTime(hour: number, minute: number): string {
+  return `${hour.toString().padStart(2, "0")}:${minute.toString().padStart(2, "0")}`;
+}
+
+function describeTime(expression: CronExpression): string {
+  if (
+    expression.minute.kind === "step" &&
+    expression.minute.base.kind === "wildcard" &&
+    expression.hour.kind === "wildcard"
+  ) {
+    return `Every ${expression.minute.step} minutes`;
+  }
+
+  if (expression.minute.kind === "wildcard" && expression.hour.kind === "wildcard") {
+    return "Every minute";
+  }
+
+  if (expression.minute.kind === "value" && expression.hour.kind === "value") {
+    return `At ${formatTime(expression.hour.value, expression.minute.value)}`;
+  }
+
+  if (expression.minute.kind === "value" && expression.hour.kind === "wildcard") {
+    return `At minute ${expression.minute.value} past every hour`;
+  }
+
+  return `Runs on a custom ${expression.minute.raw} ${expression.hour.raw} schedule`;
+}
+
+function describeDayAndMonth(expression: CronExpression): string {
+  const hasDayOfMonth = !isWildcard(expression.dayOfMonth);
+  const hasMonth = !isWildcard(expression.month);
+  const hasDayOfWeek = !isWildcard(expression.dayOfWeek);
+
+  if (!hasDayOfMonth && !hasMonth && !hasDayOfWeek) {
+    return "every day";
+  }
+
+  if (!hasDayOfMonth && !hasMonth && expression.dayOfWeek.kind === "value") {
+    return `on ${WEEKDAY_NAMES[expression.dayOfWeek.value]}`;
+  }
+
+  if (expression.dayOfMonth.kind === "value" && !hasMonth && !hasDayOfWeek) {
+    return `on day ${expression.dayOfMonth.value} of every month`;
+  }
+
+  return `when ${expression.dayOfMonth.raw} ${expression.month.raw} ${expression.dayOfWeek.raw} matches`;
+}
+
+function getDatePart(
+  date: Date,
+  mode: CronTimeZoneMode,
+  field: "minute" | "hour" | "day" | "month" | "weekday"
+) {
+  if (mode === "utc") {
+    if (field === "minute") return date.getUTCMinutes();
+    if (field === "hour") return date.getUTCHours();
+    if (field === "day") return date.getUTCDate();
+    if (field === "month") return date.getUTCMonth() + 1;
+    return date.getUTCDay();
+  }
+
+  if (field === "minute") return date.getMinutes();
+  if (field === "hour") return date.getHours();
+  if (field === "day") return date.getDate();
+  if (field === "month") return date.getMonth() + 1;
+  return date.getDay();
+}
+
+function roundUpToNextMinute(date: Date, mode: CronTimeZoneMode): Date {
+  const next = new Date(date.getTime());
+
+  if (mode === "utc") {
+    next.setUTCSeconds(0, 0);
+    next.setUTCMinutes(next.getUTCMinutes() + 1);
+    return next;
+  }
+
+  next.setSeconds(0, 0);
+  next.setMinutes(next.getMinutes() + 1);
+  return next;
+}
+
+function addOneMinute(date: Date, mode: CronTimeZoneMode): Date {
+  const next = new Date(date.getTime());
+  if (mode === "utc") {
+    next.setUTCMinutes(next.getUTCMinutes() + 1);
+    return next;
+  }
+
+  next.setMinutes(next.getMinutes() + 1);
+  return next;
+}
+
+function matchesDate(expression: CronExpression, date: Date, mode: CronTimeZoneMode): boolean {
+  const minuteMatches = expandField(
+    expression.minute,
+    CRON_FIELD_SPECS.minute.min,
+    CRON_FIELD_SPECS.minute.max
+  ).includes(getDatePart(date, mode, "minute"));
+  const hourMatches = expandField(
+    expression.hour,
+    CRON_FIELD_SPECS.hour.min,
+    CRON_FIELD_SPECS.hour.max
+  ).includes(getDatePart(date, mode, "hour"));
+  const monthMatches = expandField(
+    expression.month,
+    CRON_FIELD_SPECS.month.min,
+    CRON_FIELD_SPECS.month.max
+  ).includes(getDatePart(date, mode, "month"));
+  const dayOfMonthMatches = expandField(
+    expression.dayOfMonth,
+    CRON_FIELD_SPECS.dayOfMonth.min,
+    CRON_FIELD_SPECS.dayOfMonth.max
+  ).includes(getDatePart(date, mode, "day"));
+  const dayOfWeekMatches = expandField(
+    expression.dayOfWeek,
+    CRON_FIELD_SPECS.dayOfWeek.min,
+    CRON_FIELD_SPECS.dayOfWeek.max
+  ).includes(getDatePart(date, mode, "weekday"));
+
+  const dayMatches =
+    isWildcard(expression.dayOfMonth) && isWildcard(expression.dayOfWeek)
+      ? true
+      : isWildcard(expression.dayOfMonth)
+        ? dayOfWeekMatches
+        : isWildcard(expression.dayOfWeek)
+          ? dayOfMonthMatches
+          : dayOfMonthMatches || dayOfWeekMatches;
+
+  return minuteMatches && hourMatches && monthMatches && dayMatches;
+}
+
+export function describeCronSchedule(
+  expression: CronExpression,
+  timeZone: CronTimeZoneMode
+): string {
+  const timePart = describeTime(expression);
+  const dayPart = describeDayAndMonth(expression);
+
+  if (dayPart === "every day" && (timePart === "Every minute" || timePart.startsWith("Every "))) {
+    return `${timePart} using ${timeZone === "utc" ? "UTC" : "local time"}`;
+  }
+
+  return `${timePart} ${dayPart} using ${timeZone === "utc" ? "UTC" : "local time"}`;
+}
+
+export function getNextCronRuns(
+  expression: CronExpression,
+  options: { start: Date; count: number; timeZone: CronTimeZoneMode }
+): Date[] {
+  const results: Date[] = [];
+  let cursor = roundUpToNextMinute(options.start, options.timeZone);
+  const maxIterations = 60 * 24 * 366 * 5;
+
+  for (
+    let iteration = 0;
+    iteration < maxIterations && results.length < options.count;
+    iteration += 1
+  ) {
+    if (matchesDate(expression, cursor, options.timeZone)) {
+      results.push(new Date(cursor.getTime()));
+    }
+
+    cursor = addOneMinute(cursor, options.timeZone);
+  }
+
+  return results;
+}
+
+export function buildCronScheduleSummary(
+  input: string,
+  options: { start: Date; count: number; timeZone: CronTimeZoneMode }
+): CronScheduleSummary {
+  const parsed = parseCronExpression(input);
+
+  if (!parsed.ok) {
+    return parsed;
+  }
+
+  return {
+    ok: true,
+    description: describeCronSchedule(parsed.value, options.timeZone),
+    nextRuns: getNextCronRuns(parsed.value, options),
+  };
+}

--- a/src/tools/cron/CronTool.tsx
+++ b/src/tools/cron/CronTool.tsx
@@ -1,0 +1,158 @@
+import { createMemo, createSignal, For, Show } from "solid-js";
+
+import ToolActionButton from "@/components/ToolActionButton";
+import ToolStatusMessage from "@/components/ToolStatusMessage";
+import { buildCronScheduleSummary, type CronTimeZoneMode } from "@/lib/cronSchedule";
+import { SUPPORTED_CRON_SYNTAX } from "@/lib/cron";
+
+function formatPreview(date: Date, mode: CronTimeZoneMode): string {
+  return mode === "utc"
+    ? `${date.toISOString().replace("T", " ").replace(".000Z", " UTC")}`
+    : date.toLocaleString();
+}
+
+export default function CronTool() {
+  const [input, setInput] = createSignal("30 9 * * 1");
+  const [timeZone, setTimeZone] = createSignal<CronTimeZoneMode>("local");
+
+  const summary = createMemo(() =>
+    buildCronScheduleSummary(input(), {
+      start: new Date(),
+      count: 5,
+      timeZone: timeZone(),
+    })
+  );
+  const description = createMemo(() => {
+    const current = summary();
+    return current.ok ? current.description : "";
+  });
+  const nextRuns = createMemo(() => {
+    const current = summary();
+    return current.ok ? current.nextRuns : [];
+  });
+  const error = createMemo(() => {
+    const current = summary();
+    return current.ok ? "" : current.error.message;
+  });
+
+  const labelStyle = {
+    "font-size": "0.75rem",
+    "font-weight": "600" as const,
+    "letter-spacing": "0.05em",
+    "text-transform": "uppercase" as const,
+    color: "var(--text-secondary)",
+  };
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        "flex-direction": "column",
+        gap: "1.25rem",
+        padding: "1.5rem",
+        "max-width": "900px",
+        margin: "0 auto",
+        width: "100%",
+      }}
+    >
+      <div style={{ display: "flex", "flex-direction": "column", gap: "0.375rem" }}>
+        <label style={labelStyle}>Cron expression</label>
+        <input
+          type="text"
+          value={input()}
+          onInput={(event) => setInput(event.currentTarget.value)}
+          spellcheck={false}
+          style={{
+            width: "100%",
+            padding: "0.875rem 1rem",
+            "border-radius": "0.5rem",
+            border: `1px solid ${error() ? "var(--accent-error)" : "var(--border)"}`,
+            background: "var(--bg-secondary)",
+            color: "var(--text-primary)",
+            "font-family": "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+            "font-size": "0.9375rem",
+            outline: "none",
+            "box-sizing": "border-box",
+          }}
+        />
+      </div>
+
+      <div style={{ display: "flex", gap: "0.5rem", "flex-wrap": "wrap", "align-items": "center" }}>
+        <span style={labelStyle}>Timezone</span>
+        <ToolActionButton
+          active={timeZone() === "local"}
+          variant={timeZone() === "local" ? "primary" : "secondary"}
+          onClick={() => setTimeZone("local")}
+        >
+          Local time
+        </ToolActionButton>
+        <ToolActionButton
+          active={timeZone() === "utc"}
+          variant={timeZone() === "utc" ? "primary" : "secondary"}
+          onClick={() => setTimeZone("utc")}
+        >
+          UTC
+        </ToolActionButton>
+      </div>
+
+      <Show
+        when={!error()}
+        fallback={<ToolStatusMessage tone="error">{error()}</ToolStatusMessage>}
+      >
+        <section
+          style={{
+            display: "flex",
+            "flex-direction": "column",
+            gap: "0.75rem",
+            padding: "1rem",
+            background: "var(--bg-secondary)",
+            border: "1px solid var(--border)",
+            "border-radius": "0.75rem",
+          }}
+        >
+          <span style={labelStyle}>Humanized schedule</span>
+          <strong style={{ color: "var(--text-primary)", "font-size": "1.1rem" }}>
+            {description()}
+          </strong>
+        </section>
+
+        <section
+          style={{
+            display: "flex",
+            "flex-direction": "column",
+            gap: "0.75rem",
+            padding: "1rem",
+            background: "var(--bg-secondary)",
+            border: "1px solid var(--border)",
+            "border-radius": "0.75rem",
+          }}
+        >
+          <span style={labelStyle}>Next runs</span>
+          <div style={{ display: "flex", "flex-direction": "column", gap: "0.5rem" }}>
+            <For each={nextRuns()}>
+              {(run, index) => (
+                <code
+                  style={{
+                    padding: "0.625rem 0.75rem",
+                    background: "var(--bg-primary)",
+                    border: "1px solid var(--border)",
+                    "border-radius": "0.5rem",
+                    color: "var(--text-primary)",
+                    display: "block",
+                  }}
+                >
+                  {index() + 1}. {formatPreview(run, timeZone())}
+                </code>
+              )}
+            </For>
+          </div>
+        </section>
+      </Show>
+
+      <ToolStatusMessage tone="muted">
+        Supported subset: {SUPPORTED_CRON_SYNTAX.fieldOrder.join(" ")} · operators{" "}
+        {SUPPORTED_CRON_SYNTAX.operators.join(" ")} · preview computation stays local-only.
+      </ToolStatusMessage>
+    </div>
+  );
+}

--- a/src/tools/registry.test.ts
+++ b/src/tools/registry.test.ts
@@ -120,4 +120,12 @@ describe("tool registry", () => {
       componentPath: "/src/tools/url-inspector/UrlInspectorTool.tsx",
     });
   });
+
+  it("includes the cron route", () => {
+    expect(getToolBySlug("cron")).toMatchObject({
+      id: "cron",
+      category: "time",
+      componentPath: "/src/tools/cron/CronTool.tsx",
+    });
+  });
 });

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -230,6 +230,16 @@ export const tools: Tool[] = [
     slug: "url-inspector",
     componentPath: "/src/tools/url-inspector/UrlInspectorTool.tsx",
   },
+  {
+    id: "cron",
+    name: "Cron Schedule",
+    description: "Parse supported cron syntax, humanize it, and preview upcoming runs locally.",
+    category: "time",
+    keywords: ["cron", "schedule", "time", "parser", "preview", "humanize"],
+    icon: "CalendarClock",
+    slug: "cron",
+    componentPath: "/src/tools/cron/CronTool.tsx",
+  },
 ];
 
 export function getToolRoute(slug: string): `/tools/${string}` {


### PR DESCRIPTION
## Summary
Add the second cron slice by turning the existing parser core into a usable local tool with humanized schedule text and next-run previews. The implementation keeps the logic in `src/lib/*`, makes timezone handling explicit, and registers the final cron tool through the shared registry.

## Issue coverage
- #133 — fully addressed: adds humanized schedule output and local next-run previews on top of the shipped parser core.
- #86 — fully addressed: the cron umbrella is now complete with parser/validation, humanized output, documented supported syntax, explicit timezone handling, and a registered tool route.
- #134 — fully addressed: the full tracked next-wave tool backlog from the roadmap issue is now implemented.

## Changes
- add cron schedule helpers that humanize supported expressions and compute upcoming run previews for local time or UTC
- add a `cron` tool with parser-backed validation, explicit timezone toggles, humanized output, and upcoming run previews
- extend registry coverage with a route smoke assertion for the new tool

## Testing
- [x] `bun run test src/lib/cronSchedule.test.ts src/tools/registry.test.ts`
- [x] `bun run verify`
- [ ] manually verify simple schedules, step values, weekday-specific schedules, and timezone changes in the browser

## References
- Closes #133
- Closes #86
- Closes #134
